### PR TITLE
CodeLite import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 build
 .kdev4
-
-# CodeLite's CMake plugin stuff
-.cmake_dirty
-*.mk

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 build
 .kdev4
+
+# CodeLite's CMake plugin stuff
+.cmake_dirty
+*.mk

--- a/Quaternion.project
+++ b/Quaternion.project
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Project Name="Quaternion" InternalType="GUI">
+  <Plugins>
+    <Plugin Name="qmake">
+      <![CDATA[00010001N0005Debug000000000000]]>
+    </Plugin>
+    <Plugin Name="CMakePlugin">
+      <![CDATA[[{
+  "name": "Debug",
+  "enabled": true,
+  "buildDirectory": "build",
+  "sourceDirectory": "$(ProjectPath)",
+  "generator": "",
+  "buildType": "Debug",
+  "arguments": ["-DCMAKE_PREFIX_PATH=D:\\KDE\n-DCMAKE_POLICY_DEFAULT_CMP0028=NEW"],
+  "parentProject": ""
+ }]]]>
+    </Plugin>
+  </Plugins>
+  <Description/>
+  <Dependencies/>
+  <VirtualDirectory Name="client">
+    <File Name="client/chatroomwidget.cpp"/>
+    <File Name="client/chatroomwidget.h"/>
+    <File Name="client/logindialog.cpp"/>
+    <File Name="client/logindialog.h"/>
+    <File Name="client/main.cpp"/>
+    <File Name="client/mainwindow.cpp"/>
+    <File Name="client/mainwindow.h"/>
+    <File Name="client/roomlistdock.cpp"/>
+    <File Name="client/roomlistdock.h"/>
+    <File Name="client/userlistdock.cpp"/>
+    <File Name="client/userlistdock.h"/>
+    <VirtualDirectory Name="models">
+      <File Name="client/models/messageeventmodel.cpp"/>
+      <File Name="client/models/messageeventmodel.h"/>
+      <File Name="client/models/roomlistmodel.cpp"/>
+      <File Name="client/models/roomlistmodel.h"/>
+      <File Name="client/models/userlistmodel.cpp"/>
+      <File Name="client/models/userlistmodel.h"/>
+    </VirtualDirectory>
+  </VirtualDirectory>
+  <VirtualDirectory Name="lib">
+    <File Name="lib/connection.cpp"/>
+    <File Name="lib/connection.h"/>
+    <File Name="lib/connectiondata.cpp"/>
+    <File Name="lib/connectiondata.h"/>
+    <File Name="lib/connectionprivate.cpp"/>
+    <File Name="lib/connectionprivate.h"/>
+    <File Name="lib/joinstate.h"/>
+    <File Name="lib/logmessage.cpp"/>
+    <File Name="lib/logmessage.h"/>
+    <File Name="lib/room.cpp"/>
+    <File Name="lib/room.h"/>
+    <File Name="lib/state.cpp"/>
+    <File Name="lib/state.h"/>
+    <File Name="lib/user.cpp"/>
+    <File Name="lib/user.h"/>
+    <VirtualDirectory Name="events">
+      <File Name="lib/events/event.cpp"/>
+      <File Name="lib/events/event.h"/>
+      <File Name="lib/events/roomaliasesevent.cpp"/>
+      <File Name="lib/events/roomaliasesevent.h"/>
+      <File Name="lib/events/roomcanonicalaliasevent.cpp"/>
+      <File Name="lib/events/roomcanonicalaliasevent.h"/>
+      <File Name="lib/events/roommemberevent.cpp"/>
+      <File Name="lib/events/roommemberevent.h"/>
+      <File Name="lib/events/roommessageevent.cpp"/>
+      <File Name="lib/events/roommessageevent.h"/>
+      <File Name="lib/events/roomtopicevent.cpp"/>
+      <File Name="lib/events/roomtopicevent.h"/>
+      <File Name="lib/events/typingevent.cpp"/>
+      <File Name="lib/events/typingevent.h"/>
+      <File Name="lib/events/unknownevent.cpp"/>
+      <File Name="lib/events/unknownevent.h"/>
+    </VirtualDirectory>
+    <VirtualDirectory Name="jobs">
+      <File Name="lib/jobs/basejob.cpp"/>
+      <File Name="lib/jobs/basejob.h"/>
+      <File Name="lib/jobs/checkauthmethods.cpp"/>
+      <File Name="lib/jobs/checkauthmethods.h"/>
+      <File Name="lib/jobs/geteventsjob.cpp"/>
+      <File Name="lib/jobs/geteventsjob.h"/>
+      <File Name="lib/jobs/initialsyncjob.cpp"/>
+      <File Name="lib/jobs/initialsyncjob.h"/>
+      <File Name="lib/jobs/joinroomjob.cpp"/>
+      <File Name="lib/jobs/joinroomjob.h"/>
+      <File Name="lib/jobs/leaveroomjob.cpp"/>
+      <File Name="lib/jobs/leaveroomjob.h"/>
+      <File Name="lib/jobs/passwordlogin.cpp"/>
+      <File Name="lib/jobs/passwordlogin.h"/>
+      <File Name="lib/jobs/postmessagejob.cpp"/>
+      <File Name="lib/jobs/postmessagejob.h"/>
+      <File Name="lib/jobs/roommembersjob.cpp"/>
+      <File Name="lib/jobs/roommembersjob.h"/>
+      <File Name="lib/jobs/syncjob.cpp"/>
+      <File Name="lib/jobs/syncjob.h"/>
+    </VirtualDirectory>
+  </VirtualDirectory>
+  <VirtualDirectory Name="resources">
+    <File Name="CMakeLists.txt"/>
+  </VirtualDirectory>
+  <Settings Type="Executable">
+    <GlobalSettings>
+      <Compiler Options="-pedantic;-W;-std=c++14;-Wall" C_Options="-pedantic;-W;-std=c99;-Wall" Assembler="">
+        <IncludePath Value="."/>
+      </Compiler>
+      <Linker Options="">
+        <LibraryPath Value="."/>
+      </Linker>
+      <ResourceCompiler Options=""/>
+    </GlobalSettings>
+    <Configuration Name="Debug" CompilerType="MinGW ( mingw64 )" DebuggerType="GNU gdb debugger" Type="Executable" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
+      <Compiler Options="" C_Options="" Assembler="" Required="no" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0"/>
+      <Linker Options="" Required="no"/>
+      <ResourceCompiler Options="" Required="no"/>
+      <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="$(WorkspacePath)/build" Command="$(IntermediateDirectory)/quaternion" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
+        <![CDATA[]]>
+      </Environment>
+      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="no">
+        <DebuggerSearchPaths/>
+        <PostConnectCommands/>
+        <StartupCommands/>
+      </Debugger>
+      <PreBuild/>
+      <PostBuild/>
+      <CustomBuild Enabled="no">
+        <RebuildCommand/>
+        <CleanCommand/>
+        <BuildCommand/>
+        <PreprocessFileCommand/>
+        <SingleFileCommand/>
+        <MakefileGenerationCommand/>
+        <ThirdPartyToolName>None</ThirdPartyToolName>
+        <WorkingDirectory/>
+      </CustomBuild>
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild/>
+      </AdditionalRules>
+      <Completion EnableCpp11="no" EnableCpp14="no">
+        <ClangCmpFlagsC/>
+        <ClangCmpFlags/>
+        <ClangPP/>
+        <SearchPaths/>
+      </Completion>
+    </Configuration>
+    <Configuration Name="Release" CompilerType="MinGW ( mingw64 )" DebuggerType="GNU gdb debugger" Type="Executable" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
+      <Compiler Options="-O2;-W" C_Options="-O2;-W" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0">
+        <IncludePath Value="."/>
+        <IncludePath Value="/usr/include/qt4"/>
+        <IncludePath Value="/usr/include/qt4/QtGui"/>
+      </Compiler>
+      <Linker Options="-s" Required="yes">
+        <LibraryPath Value="/usr/lib/qt4"/>
+        <Library Value="QtCore"/>
+        <Library Value="QtGui"/>
+      </Linker>
+      <ResourceCompiler Options="" Required="no"/>
+      <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="./Release" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
+      <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
+        <![CDATA[]]>
+      </Environment>
+      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="no">
+        <DebuggerSearchPaths/>
+        <PostConnectCommands/>
+        <StartupCommands/>
+      </Debugger>
+      <PreBuild/>
+      <PostBuild/>
+      <CustomBuild Enabled="no">
+        <RebuildCommand/>
+        <CleanCommand/>
+        <BuildCommand/>
+        <PreprocessFileCommand/>
+        <SingleFileCommand/>
+        <MakefileGenerationCommand/>
+        <ThirdPartyToolName>None</ThirdPartyToolName>
+        <WorkingDirectory/>
+      </CustomBuild>
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild/>
+      </AdditionalRules>
+      <Completion EnableCpp11="no" EnableCpp14="no">
+        <ClangCmpFlagsC/>
+        <ClangCmpFlags/>
+        <ClangPP/>
+        <SearchPaths/>
+      </Completion>
+    </Configuration>
+  </Settings>
+</CodeLite_Project>

--- a/Quaternion.project
+++ b/Quaternion.project
@@ -1,22 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeLite_Project Name="Quaternion" InternalType="GUI">
-  <Plugins>
-    <Plugin Name="qmake">
-      <![CDATA[00010001N0005Debug000000000000]]>
-    </Plugin>
-    <Plugin Name="CMakePlugin">
-      <![CDATA[[{
-  "name": "Debug",
-  "enabled": true,
-  "buildDirectory": "build",
-  "sourceDirectory": "$(ProjectPath)",
-  "generator": "",
-  "buildType": "Debug",
-  "arguments": ["-DCMAKE_PREFIX_PATH=D:\\KDE\n-DCMAKE_POLICY_DEFAULT_CMP0028=NEW"],
-  "parentProject": ""
- }]]]>
-    </Plugin>
-  </Plugins>
+  <Reconciliation>
+    <Regexes/>
+    <Excludepaths/>
+    <Ignorefiles/>
+    <Extensions>
+      <![CDATA[cpp;c;h;hpp;xrc;wxcp;fbp;qrc;md]]>
+    </Extensions>
+    <Topleveldir>.</Topleveldir>
+  </Reconciliation>
   <Description/>
   <Dependencies/>
   <VirtualDirectory Name="client">
@@ -39,6 +31,7 @@
       <File Name="client/models/userlistmodel.cpp"/>
       <File Name="client/models/userlistmodel.h"/>
     </VirtualDirectory>
+    <File Name="client/resources.qrc"/>
   </VirtualDirectory>
   <VirtualDirectory Name="lib">
     <File Name="lib/connection.cpp"/>
@@ -95,14 +88,20 @@
       <File Name="lib/jobs/roommembersjob.h"/>
       <File Name="lib/jobs/syncjob.cpp"/>
       <File Name="lib/jobs/syncjob.h"/>
+      <File Name="lib/jobs/mediathumbnailjob.cpp"/>
+      <File Name="lib/jobs/mediathumbnailjob.h"/>
+      <File Name="lib/jobs/roommessagesjob.cpp"/>
+      <File Name="lib/jobs/roommessagesjob.h"/>
     </VirtualDirectory>
   </VirtualDirectory>
   <VirtualDirectory Name="resources">
-    <File Name="CMakeLists.txt"/>
+    <File Name="README.md"/>
   </VirtualDirectory>
+  <Dependencies Name="Debug"/>
+  <Dependencies Name="Release"/>
   <Settings Type="Executable">
     <GlobalSettings>
-      <Compiler Options="-pedantic;-W;-std=c++14;-Wall" C_Options="-pedantic;-W;-std=c99;-Wall" Assembler="">
+      <Compiler Options="" C_Options="" Assembler="">
         <IncludePath Value="."/>
       </Compiler>
       <Linker Options="">
@@ -113,33 +112,34 @@
     <Configuration Name="Debug" CompilerType="MinGW ( mingw64 )" DebuggerType="GNU gdb debugger" Type="Executable" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
       <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0"/>
       <Linker Options="" Required="yes"/>
-      <ResourceCompiler Options="" Required="no"/>
-      <General OutputFile="$(IntermediateDirectory)/quaternion" IntermediateDirectory="$(WorkspacePath)/build" Command="D:\KDE\bin\quaternion" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="D:/KDE/bin" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <ResourceCompiler Options="" Required="yes"/>
+      <General OutputFile="$(IntermediateDirectory)/quaternion" IntermediateDirectory="$(ProjectPath)/build" Command="quaternion" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
-      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="no">
+      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="yes">
         <DebuggerSearchPaths/>
         <PostConnectCommands/>
         <StartupCommands/>
       </Debugger>
       <PreBuild/>
       <PostBuild/>
-      <CustomBuild Enabled="no">
-        <RebuildCommand/>
-        <CleanCommand/>
-        <BuildCommand/>
+      <CustomBuild Enabled="yes">
+        <Target Name="CMake">cmake $(ProjectPath) -G "MinGW Makefiles"  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <RebuildCommand>mingw32-make clean &amp;&amp; mingw32-make -j4</RebuildCommand>
+        <CleanCommand>mingw32-make clean</CleanCommand>
+        <BuildCommand>mingw32-make -j4</BuildCommand>
         <PreprocessFileCommand/>
         <SingleFileCommand/>
         <MakefileGenerationCommand/>
         <ThirdPartyToolName>None</ThirdPartyToolName>
-        <WorkingDirectory/>
+        <WorkingDirectory>$(IntermediateDirectory)</WorkingDirectory>
       </CustomBuild>
       <AdditionalRules>
         <CustomPostBuild/>
         <CustomPreBuild/>
       </AdditionalRules>
-      <Completion EnableCpp11="no" EnableCpp14="yes">
+      <Completion EnableCpp11="yes" EnableCpp14="no">
         <ClangCmpFlagsC/>
         <ClangCmpFlags/>
         <ClangPP/>
@@ -147,43 +147,36 @@
       </Completion>
     </Configuration>
     <Configuration Name="Release" CompilerType="MinGW ( mingw64 )" DebuggerType="GNU gdb debugger" Type="Executable" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="-O2;-W" C_Options="-O2;-W" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0">
-        <IncludePath Value="."/>
-        <IncludePath Value="/usr/include/qt4"/>
-        <IncludePath Value="/usr/include/qt4/QtGui"/>
-      </Compiler>
-      <Linker Options="-s" Required="yes">
-        <LibraryPath Value="/usr/lib/qt4"/>
-        <Library Value="QtCore"/>
-        <Library Value="QtGui"/>
-      </Linker>
-      <ResourceCompiler Options="" Required="no"/>
-      <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="./Release" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="no" IsGUIProgram="no" IsEnabled="yes"/>
+      <Compiler Options="" C_Options="" Assembler="" Required="no" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0"/>
+      <Linker Options="" Required="no"/>
+      <ResourceCompiler Options="" Required="yes"/>
+      <General OutputFile="$(IntermediateDirectory)/quaternion" IntermediateDirectory="$(ProjectPath)/build" Command="quaternion" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="no" IsGUIProgram="yes" IsEnabled="yes"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
-      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="no">
+      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="yes">
         <DebuggerSearchPaths/>
         <PostConnectCommands/>
         <StartupCommands/>
       </Debugger>
       <PreBuild/>
       <PostBuild/>
-      <CustomBuild Enabled="no">
-        <RebuildCommand/>
-        <CleanCommand/>
-        <BuildCommand/>
+      <CustomBuild Enabled="yes">
+        <Target Name="CMake">cmake $(ProjectPath) -G "MinGW Makefiles"  -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <RebuildCommand>mingw32-make clean &amp;&amp; mingw32-make -j4</RebuildCommand>
+        <CleanCommand>mingw32-make clean</CleanCommand>
+        <BuildCommand>mingw32-make -j4</BuildCommand>
         <PreprocessFileCommand/>
         <SingleFileCommand/>
         <MakefileGenerationCommand/>
         <ThirdPartyToolName>None</ThirdPartyToolName>
-        <WorkingDirectory/>
+        <WorkingDirectory>$(IntermediateDirectory)</WorkingDirectory>
       </CustomBuild>
       <AdditionalRules>
         <CustomPostBuild/>
         <CustomPreBuild/>
       </AdditionalRules>
-      <Completion EnableCpp11="no" EnableCpp14="no">
+      <Completion EnableCpp11="yes" EnableCpp14="no">
         <ClangCmpFlagsC/>
         <ClangCmpFlags/>
         <ClangPP/>

--- a/Quaternion.project
+++ b/Quaternion.project
@@ -111,10 +111,10 @@
       <ResourceCompiler Options=""/>
     </GlobalSettings>
     <Configuration Name="Debug" CompilerType="MinGW ( mingw64 )" DebuggerType="GNU gdb debugger" Type="Executable" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
-      <Compiler Options="" C_Options="" Assembler="" Required="no" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0"/>
-      <Linker Options="" Required="no"/>
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0"/>
+      <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
-      <General OutputFile="$(IntermediateDirectory)/$(ProjectName)" IntermediateDirectory="$(WorkspacePath)/build" Command="$(IntermediateDirectory)/quaternion" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="$(IntermediateDirectory)" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <General OutputFile="$(IntermediateDirectory)/quaternion" IntermediateDirectory="$(WorkspacePath)/build" Command="D:\KDE\bin\quaternion" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="D:/KDE/bin" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
@@ -139,7 +139,7 @@
         <CustomPostBuild/>
         <CustomPreBuild/>
       </AdditionalRules>
-      <Completion EnableCpp11="no" EnableCpp14="no">
+      <Completion EnableCpp11="no" EnableCpp14="yes">
         <ClangCmpFlagsC/>
         <ClangCmpFlags/>
         <ClangPP/>


### PR DESCRIPTION
After playing with different configurations I ended up adding just a single CodeLite .project file under version control (it should work under Linux, too - but I don't have a place to check). Building it implies that one has a healthy CMake in PATH and Qt+KCoreAddons rolled out somewhere. I'll follow up with writing an instruction to README.md regarding that - if you think it's better to pull everything at once, let me know.