### PR TITLE
SyncJob::Private::parseEvents refactoring

### DIFF
--- a/lib/jobs/syncjob.h
+++ b/lib/jobs/syncjob.h
@@ -39,11 +39,11 @@ namespace QMatrixClient
 
         bool timelineLimited;
         QString timelinePrevBatch;
+
+        SyncRoomData(QString roomId_, const QJsonObject& room_, JoinState joinState_);
     };
 
     class ConnectionData;
-    class Room;
-    class Event;
     class SyncJob: public BaseJob
     {
             Q_OBJECT


### PR DESCRIPTION
I took a refactoring run against repetitive code in SyncJob::Private::parseEvents() by making a poor-man's dispatcher loop. Besides, the whole SyncRoomData initialization seemed to belong to its own constructor, so I've made one.