### PR TITLE
Make Quaternion work with Qt 5.6

### DIFF
--- a/lib/jobs/basejob.cpp
+++ b/lib/jobs/basejob.cpp
@@ -80,6 +80,10 @@ void BaseJob::start()
     url.setQuery(query);
     QNetworkRequest req = QNetworkRequest(url);
     req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    req.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);\
+    req.setMaximumRedirectsAllowed(10);
+#endif
     QJsonDocument data = QJsonDocument(this->data());
     switch( d->type )
     {


### PR DESCRIPTION
Qt 5.6 introduced "HTTP redirects support" as they named it in What's new - thereby changing the default behaviour of QNetworkRequest: before 5.6 it used to follow redirects automatically, while in 5.6 you have to explicitly tell it to. Not sure if it's deliberate on their side - anyway, this commit makes use of the feature and fixes thumbnails loading that always goes through at least one redirect.