### PR TITLE
Fix avatar updates + minor cleanup

### DIFF
--- a/client/models/userlistmodel.h
+++ b/client/models/userlistmodel.h
@@ -44,11 +44,12 @@ class UserListModel: public QAbstractListModel
     private slots:
         void userAdded(QMatrixClient::User* user);
         void userRemoved(QMatrixClient::User* user);
-
-    private slots:
         void avatarChanged(QMatrixClient::User* user);
 
     private:
+        void connectSignals(QMatrixClient::User* user);
+        void disconnectSignals(QMatrixClient::User* user);
+
         QMatrixClient::Connection* m_connection;
         QMatrixClient::Room* m_currentRoom;
         QList<QMatrixClient::User*> m_users;

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -260,20 +260,24 @@ void Room::Private::addState(Event* event)
     if( event->type() == EventType::RoomMember )
     {
         RoomMemberEvent* memberEvent = static_cast<RoomMemberEvent*>(event);
-        User* u = connection->user(memberEvent->userId());
-        if( !u ) qDebug() << "addState: invalid user!" << u << memberEvent->userId();
-        u->processEvent(event);
-        if( memberEvent->membership() == MembershipType::Join and !users.contains(u) )
+        if (User* u = connection->user(memberEvent->userId()))
         {
-            users.append(u);
-            emit q->userAdded(u);
+            u->processEvent(event);
+            if( memberEvent->membership() == MembershipType::Join
+                    && !users.contains(u) )
+            {
+                users.append(u);
+                emit q->userAdded(u);
+            }
+            else if( memberEvent->membership() == MembershipType::Leave
+                     && users.contains(u) )
+            {
+                users.removeAll(u);
+                emit q->userRemoved(u);
+            }
         }
-        else if( memberEvent->membership() == MembershipType::Leave
-                 and users.contains(u) )
-        {
-            users.removeAll(u);
-            emit q->userRemoved(u);
-        }
+        else
+            qDebug() << "addState: invalid user!" << memberEvent->userId();
     }
 
 }

--- a/lib/room.cpp
+++ b/lib/room.cpp
@@ -260,24 +260,20 @@ void Room::Private::addState(Event* event)
     if( event->type() == EventType::RoomMember )
     {
         RoomMemberEvent* memberEvent = static_cast<RoomMemberEvent*>(event);
-        if (User* u = connection->user(memberEvent->userId()))
+        User* u = connection->user(memberEvent->userId());
+        u->processEvent(event);
+        if( memberEvent->membership() == MembershipType::Join
+            && !users.contains(u) )
         {
-            u->processEvent(event);
-            if( memberEvent->membership() == MembershipType::Join
-                    && !users.contains(u) )
-            {
-                users.append(u);
-                emit q->userAdded(u);
-            }
-            else if( memberEvent->membership() == MembershipType::Leave
-                     && users.contains(u) )
-            {
-                users.removeAll(u);
-                emit q->userRemoved(u);
-            }
+            users.append(u);
+            emit q->userAdded(u);
         }
-        else
-            qDebug() << "addState: invalid user!" << memberEvent->userId();
+        else if( memberEvent->membership() == MembershipType::Leave
+                 && users.contains(u) )
+        {
+            users.removeAll(u);
+            emit q->userRemoved(u);
+        }
     }
 
 }

--- a/lib/user.cpp
+++ b/lib/user.cpp
@@ -102,7 +102,9 @@ QPixmap User::avatar(int width, int height)
     QPair<int,int> size(width, height);
     if( !d->scaledMap.contains(size) )
     {
-        d->scaledMap.insert(size, d->avatar.scaled(width, height, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        d->scaledMap.insert(size,
+            d->avatar.scaled(width, height,
+                Qt::KeepAspectRatio, Qt::SmoothTransformation));
     }
     return d->scaledMap.value(size);
 }


### PR DESCRIPTION
For what it's worth, here's my call on the avatar updates stuff. It's basically the same but I thought it's worth it to factor out the connect/disconnect code so that once we have user data updates and other stuff coming around we could quickly add connects/disconnects to a single place (ok, two single places :) ).

I also accidentally found a messy dealing with User * in room.cpp, so I fixed that as well (it's a separate commit so you can cherrypick it if you don't like the main part of the PR).