### PR TITLE
Add flexibility on choosing the bundled vs. system KCoreAddons.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1) # Because of target_compile_features
 
 project(quaternion)
 
@@ -7,7 +7,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 
-option( BUILD_KCOREADDONS "Build KCoreAddons instead of using system version" OFF )
+# Whether to build with the bundled KCoreAddons or system KCoreAddons
+option( BUILD_KCOREADDONS "Build KCoreAddons even if there is a system version" OFF )
+option( FORCE_SYSTEM_KCOREADDONS "Fail if system KCoreAddons are not found" OFF )
 
 message( STATUS )
 message( STATUS "================================================================================" )
@@ -16,31 +18,32 @@ message( STATUS "===============================================================
 message( STATUS "Building with: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}" )
 message( STATUS "Install Prefix: ${CMAKE_INSTALL_PREFIX}" )
 message( STATUS "Build own KCoreAddons (BUILD_KCOREADDONS): ${BUILD_KCOREADDONS}" )
+if ( NOT BUILD_KCOREADDONS )
+    message( STATUS "Force using system KCoreAddons (FORCE_SYSTEM_KCOREADDONS): ${FORCE_SYSTEM_KCOREADDONS}" )
+endif ( NOT BUILD_KCOREADDONS )
 message( STATUS "================================================================================" )
 
-
-# Find the QtWidgets library
+# Find the libraries
 find_package(Qt5Widgets 5.3.0)
 find_package(Qt5Network 5.3.0)
 find_package(Qt5Quick 5.3.0)
 find_package(Qt5Qml 5.3.0)
 find_package(Qt5Gui 5.3.0)
 
-if( NOT BUILD_KCOREADDONS )
-    find_package(KF5CoreAddons REQUIRED)
-endif( NOT BUILD_KCOREADDONS )
+if ( NOT BUILD_KCOREADDONS )
+    if ( FORCE_SYSTEM_KCOREADDONS )
+        find_package(KF5CoreAddons REQUIRED)
+    else ( FORCE_SYSTEM_KCOREADDONS )
+        find_package(KF5CoreAddons QUIET)
+        if ( KF5CoreAddons_FOUND )
+            message( STATUS "Path to system KCoreAddons: ${KF5CoreAddons_DIR}" )
+        else ( KF5CoreAddons_FOUND )
+            message( STATUS "System KCoreAddons not found, using the bundled version" )
+        endif ( KF5CoreAddons_FOUND )
+    endif ( FORCE_SYSTEM_KCOREADDONS )
+endif ( NOT BUILD_KCOREADDONS )
 
-if ( BUILD_KCOREADDONS )
-    # The proper way of doing things would be to make a separate config.h.in
-    # file and use configure_file() command here to generate config.h with
-    # needed C++ preprocessor macros. If we have more than one or two
-    # dependencies like that, we should turn to that more scalable way.
-    # As for now, passing a macro through -D is easier to observe and maintain.
-    set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKCOREADDONS_FOUND" )
-else ( BUILD_KCOREADDONS )
-    include_directories( kcoreaddons/src/lib kcoreaddons/src/lib/jobs )
-endif ( BUILD_KCOREADDONS )
-
+# Set up source files
 set(qmatrixclient_SRCS
     lib/connectiondata.cpp
     lib/connection.cpp
@@ -79,14 +82,16 @@ set(qmatrixclient_SRCS
     client/main.cpp
     )
 
-if ( NOT BUILD_KCOREADDONS )
+# Add bundled KCoreAddons sources if we haven't found the system sources
+# or if we ignore them
+if ( BUILD_KCOREADDONS OR NOT KF5CoreAddons_FOUND )
     set (qmatrixclient_SRCS ${qmatrixclient_SRCS}
         kcoreaddons/src/lib/jobs/kjob.cpp
         kcoreaddons/src/lib/jobs/kcompositejob.cpp
         kcoreaddons/src/lib/jobs/kjobtrackerinterface.cpp
         kcoreaddons/src/lib/jobs/kjobuidelegate.cpp
         )
-endif ( NOT BUILD_KCOREADDONS )
+endif ( BUILD_KCOREADDONS OR NOT KF5CoreAddons_FOUND )
 
 set(qmatrixclient_QRC
     client/resources.qrc
@@ -97,15 +102,22 @@ QT5_ADD_RESOURCES(qmatrixclient_QRC_SRC ${qmatrixclient_QRC})
 # Tell CMake to create the executable
 add_executable(quaternion ${qmatrixclient_SRCS} ${qmatrixclient_QRC_SRC})
 
+# Setup command line parameters for the compiler and linker
 if ( CMAKE_COMPILER_IS_GNUCC )
-    # This is tested
-    set_property( TARGET quaternion APPEND_STRING PROPERTY COMPILE_FLAGS -Wall )
+    add_compile_options( "-Wall" )
 endif ( CMAKE_COMPILER_IS_GNUCC )
 target_compile_features(quaternion PRIVATE cxx_range_for)
 target_compile_features(quaternion PRIVATE cxx_override)
 
-if ( NOT BUILD_KCOREADDONS )
+if ( KF5CoreAddons_FOUND )
+    # The proper way of doing things would be to make a separate config.h.in
+    # file and use configure_file() command here to generate config.h with
+    # needed C++ preprocessor macros. If we have more than one or two
+    # dependencies like that, we should turn to that more scalable way.
+    # As for now, passing a macro through -D is easier to observe and maintain.
+    target_compile_definitions ( quaternion PRIVATE USING_SYSTEM_KCOREADDONS )
     target_link_libraries(quaternion Qt5::Widgets Qt5::Quick Qt5::Qml Qt5::Gui Qt5::Network KF5::CoreAddons)
-else ( NOT BUILD_KCOREADDONS )
+else ( KF5CoreAddons_FOUND )
+    include_directories( kcoreaddons/src/lib kcoreaddons/src/lib/jobs )
     target_link_libraries(quaternion Qt5::Widgets Qt5::Quick Qt5::Qml Qt5::Gui Qt5::Network)
-endif ( NOT BUILD_KCOREADDONS )
+endif ( KF5CoreAddons_FOUND )

--- a/lib/jobs/basejob.h
+++ b/lib/jobs/basejob.h
@@ -19,7 +19,7 @@
 #ifndef QMATRIXCLIENT_BASEJOB_H
 #define QMATRIXCLIENT_BASEJOB_H
 
-#ifdef KCOREADDONS_FOUND
+#ifdef USING_SYSTEM_KCOREADDONS
 #include <KCoreAddons/KJob>
 #else
 #include "kcoreaddons/src/lib/jobs/kjob.h"


### PR DESCRIPTION
I've rehashed your changes in CMakeLists and made them work (at least for cases when KCoreAddons are not in the system - with or without BUILD_* option). Plus, I've made an additional option that would please package maintainers. This allows to provide the graceful fallback as a default behaviour, as it's in the mainline.
Sorry for the bulky commit - here's the list of changes:
1. Pump up required CMake version (it didn't reflect the actual contents).
2. Add FORCE_SYSTEM_KCOREADDONS so that Linux package maintainers (at least) could make sure they build against the system package, without graceful fallbacks.
3. Add respective logic around find_package(KF5CoreAddons). Enable the graceful fallback again as a default (all options are OFF).
4. Fix adding sources from kcoreaddons/* to SRCS (the previous condition wasn't right). If FORCE_SYSTEM_KCOREADDONS is set we won't even reach this place so I don't check it.
5. Set compiler options in a nicer and more readable way.
6. Former KCOREADDONS_FOUND preprocessor macro is renamed with USING_SYSTEM_KCOREADDONS - this name better reflects the purpose.