### PR TITLE
Sync on timer

### DIFF
--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -24,9 +24,8 @@
 
 LoginDialog::LoginDialog(QWidget* parent)
     : QDialog(parent)
+    , m_connection(nullptr)
 {
-    m_connection = 0;
-    
     serverEdit = new QLineEdit("https://matrix.org");
     userEdit = new QLineEdit();
     passwordEdit = new QLineEdit();
@@ -63,6 +62,7 @@ void LoginDialog::login()
     m_connection = new QMatrixClient::Connection(url);
     connect( m_connection, &QMatrixClient::Connection::connected, this, &QDialog::accept );
     connect( m_connection, &QMatrixClient::Connection::loginError, this, &LoginDialog::error );
+    sessionLabel->setText("Logging in...");
     m_connection->connectToServer(user, password);
 }
 

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -58,7 +58,7 @@ void MainWindow::initialize()
         roomListDock->setConnection(connection);
         connect( connection, &QMatrixClient::Connection::connectionError, this, &MainWindow::connectionError );
         connect( connection, &QMatrixClient::Connection::syncDone, this, &MainWindow::gotEvents );
-        connect( connection, &QMatrixClient::Connection::reconnected, this, &MainWindow::getNewEvents );
+        connect( connection, &QMatrixClient::Connection::connected, this, &MainWindow::getNewEvents );
         connection->sync();
     }
 }
@@ -79,7 +79,7 @@ void MainWindow::connectionError(QString error)
 {
     qDebug() << error;
     qDebug() << "reconnecting...";
-    connection->reconnect();
+    connection->invokeLogin();
 }
 
 

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -44,6 +44,7 @@ class MainWindow: public QMainWindow
         void connectionError(QString error);
 
     private:
+        void setupSyncClock();
 
         RoomListDock* roomListDock;
         UserListDock* userListDock;

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -49,17 +49,15 @@ Connection::~Connection()
 
 void Connection::connectToServer(QString user, QString password)
 {
-    PasswordLogin* loginJob = new PasswordLogin(d->data, user, password);
-    connect( loginJob, &PasswordLogin::result, d, &ConnectionPrivate::connectDone );
-    loginJob->start();
     d->user = user; // to be able to reconnect
     d->password = password;
+    invokeLogin();
 }
 
-void Connection::reconnect()
+void Connection::invokeLogin()
 {
     PasswordLogin* loginJob = new PasswordLogin(d->data, d->user, d->password );
-    connect( loginJob, &PasswordLogin::result, d, &ConnectionPrivate::reconnectDone );
+    connect( loginJob, &PasswordLogin::result, d, &ConnectionPrivate::connectDone );
     loginJob->start();
 }
 

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -61,17 +61,14 @@ void Connection::invokeLogin()
 
 void Connection::sync()
 {
-    doSync();
-}
+    if (d->syncJob)
+        return;
 
-SyncJob* Connection::doSync()
-{
     QString filter = "{\"room\": { \"timeline\": { \"limit\": 100 } } }";
-    SyncJob* syncJob = new SyncJob(d->data, d->data->lastEvent());
-    syncJob->setFilter(filter);
-    connect( syncJob, &SyncJob::result, d, &ConnectionPrivate::syncDone );
-    syncJob->start();
-    return syncJob;
+    d->syncJob = new SyncJob(d->data, d->data->lastEvent());
+    d->syncJob->setFilter(filter);
+    connect( d->syncJob, &SyncJob::result, d, &ConnectionPrivate::syncDone );
+    d->syncJob->start();
 }
 
 void Connection::postMessage(Room* room, QString type, QString message)

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -31,8 +31,6 @@
 #include "jobs/syncjob.h"
 #include "jobs/mediathumbnailjob.h"
 
-#include <QtCore/QDebug>
-
 using namespace QMatrixClient;
 
 Connection::Connection(QUrl server, QObject* parent)
@@ -61,7 +59,12 @@ void Connection::invokeLogin()
     loginJob->start();
 }
 
-SyncJob* Connection::sync()
+void Connection::sync()
+{
+    doSync();
+}
+
+SyncJob* Connection::doSync()
 {
     QString filter = "{\"room\": { \"timeline\": { \"limit\": 100 } } }";
     SyncJob* syncJob = new SyncJob(d->data, d->data->lastEvent());

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -42,7 +42,7 @@ namespace QMatrixClient
 
             void connectToServer( QString user, QString password );
             void invokeLogin();
-            SyncJob* sync();
+            SyncJob* doSync();
             void postMessage( Room* room, QString type, QString message );
             void joinRoom( QString roomAlias );
             void leaveRoom( Room* room );
@@ -61,6 +61,9 @@ namespace QMatrixClient
             void loginError(QString error);
             void connectionError(QString error);
             //void jobError(BaseJob* job);
+
+        public slots:
+            void sync();
 
         private:
             ConnectionPrivate* d;

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -42,7 +42,6 @@ namespace QMatrixClient
 
             void connectToServer( QString user, QString password );
             void invokeLogin();
-            SyncJob* doSync();
             void postMessage( Room* room, QString type, QString message );
             void joinRoom( QString roomAlias );
             void leaveRoom( Room* room );

--- a/lib/connection.h
+++ b/lib/connection.h
@@ -41,7 +41,7 @@ namespace QMatrixClient
             bool isConnected();
 
             void connectToServer( QString user, QString password );
-            void reconnect();
+            void invokeLogin();
             SyncJob* sync();
             void postMessage( Room* room, QString type, QString message );
             void joinRoom( QString roomAlias );
@@ -54,7 +54,6 @@ namespace QMatrixClient
 
         signals:
             void connected();
-            void reconnected();
             void syncDone();
             void newRoom(Room* room);
             void joinedRoom(Room* room);

--- a/lib/connectionprivate.cpp
+++ b/lib/connectionprivate.cpp
@@ -96,20 +96,8 @@ void ConnectionPrivate::connectDone(KJob* job)
         emit q->connected();
     }
     else {
-        emit q->loginError( job->errorString() );
-    }
-}
-
-void ConnectionPrivate::reconnectDone(KJob* job)
-{
-    PasswordLogin* realJob = static_cast<PasswordLogin*>(job);
-    if( !realJob->error() )
-    {
-        emit q->reconnected();
-    }
-    else {
-        emit q->loginError( job->errorString() );
         isConnected = false;
+        emit q->loginError( job->errorString() );
     }
 }
 

--- a/lib/connectionprivate.cpp
+++ b/lib/connectionprivate.cpp
@@ -36,6 +36,7 @@ using namespace QMatrixClient;
 
 ConnectionPrivate::ConnectionPrivate(Connection* parent)
     : q(parent)
+    , syncJob(nullptr)
 {
     isConnected = false;
     data = 0;
@@ -103,17 +104,18 @@ void ConnectionPrivate::connectDone(KJob* job)
 
 void ConnectionPrivate::syncDone(KJob* job)
 {
-    SyncJob* syncJob = static_cast<SyncJob*>(job);
-    if( !syncJob->error() )
+    SyncJob* finishedSync = static_cast<SyncJob*>(job);
+    if( !finishedSync->error() )
     {
-        data->setLastEvent(syncJob->nextBatch());
-        processRooms(syncJob->roomData());
+        data->setLastEvent(finishedSync->nextBatch());
+        processRooms(finishedSync->roomData());
         emit q->syncDone();
     }
     else {
-        if( syncJob->error() == BaseJob::NetworkError )
-            emit q->connectionError( syncJob->errorString() );
+        if( finishedSync->error() == BaseJob::NetworkError )
+            emit q->connectionError( finishedSync->errorString() );
     }
+    syncJob = nullptr;
 }
 
 void ConnectionPrivate::gotJoinRoom(KJob* job)

--- a/lib/connectionprivate.h
+++ b/lib/connectionprivate.h
@@ -53,10 +53,10 @@ namespace QMatrixClient
             bool isConnected;
             QString user;
             QString password;
+            SyncJob* syncJob;
 
         public slots:
             void connectDone(KJob* job);
-            void reconnectDone(KJob* job);
             void syncDone(KJob* job);
             void gotJoinRoom(KJob* job);
             void gotRoomMembers(KJob* job);


### PR DESCRIPTION
This is independent (as much as possible) from the pull request about user/room names and based on the same commit as the other one. Basically, I've made syncs work the way I think is proper - by a timer rather than immediately invoke the next sync once the previous is finished. The commits in this PR should be taken together - the last one fixes a linking error by the first one.