### PR TITLE
Disconnect sync slots on closing the main window.

### DIFF
--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -72,8 +72,7 @@ void MainWindow::getNewEvents()
 void MainWindow::gotEvents()
 {
     // qDebug() << "newEvents";
-    // without the 1 ms wait, the application will never quit
-    QTimer::singleShot(1, this, SLOT(getNewEvents()));
+    getNewEvents();
 }
 
 void MainWindow::connectionError(QString error)
@@ -81,6 +80,16 @@ void MainWindow::connectionError(QString error)
     qDebug() << error;
     qDebug() << "reconnecting...";
     connection->reconnect();
+}
+
+void MainWindow::closeEvent(QCloseEvent* event)
+{
+    if (connection)
+    {
+        disconnect( connection, &QMatrixClient::Connection::syncDone, this, &MainWindow::gotEvents );
+        disconnect( connection, &QMatrixClient::Connection::reconnected, this, &MainWindow::getNewEvents );
+    }
+    event->accept();
 }
 
 

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -43,6 +43,9 @@ class MainWindow: public QMainWindow
 
         void connectionError(QString error);
 
+    protected:
+        virtual void closeEvent(QCloseEvent* event) override;
+
     private:
 
         RoomListDock* roomListDock;


### PR DESCRIPTION
This makes a clean exit without the 1ms workaround (actually, without a QTimer at all).