### PR TITLE
User/room names, take 2 - Quaternion part

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -39,6 +39,7 @@
 #include "quaternionroom.h"
 
 ChatRoomWidget::ChatRoomWidget(QWidget* parent)
+    : QWidget(parent)
 {
     m_messageModel = new MessageEventModel(this);
     m_currentRoom = nullptr;
@@ -52,7 +53,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     QQmlContext* ctxt = m_quickView->rootContext();
     ctxt->setContextProperty("messageModel", m_messageModel);
-    ctxt->setContextProperty("debug", false);
+    ctxt->setContextProperty("debug", QVariant(false));
     m_quickView->setSource(QUrl("qrc:///qml/chat.qml"));
     m_quickView->setResizeMode(QQuickView::SizeRootObjectToView);
 
@@ -88,8 +89,7 @@ void ChatRoomWidget::setRoom(QMatrixClient::Room* room)
 {
     if( m_currentRoom )
     {
-        disconnect( m_currentRoom, &QMatrixClient::Room::typingChanged, this, &ChatRoomWidget::typingChanged );
-        disconnect( m_currentRoom, &QMatrixClient::Room::topicChanged, this, &ChatRoomWidget::topicChanged );
+        m_currentRoom->disconnect( this );
         m_currentRoom->setShown(false);
     }
     m_currentRoom = static_cast<QuaternionRoom*>(room);

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -123,7 +123,7 @@ void ChatRoomWidget::typingChanged()
     QStringList typingNames;
     for( QMatrixClient::User* user: typing )
     {
-        typingNames << user->displayname();
+        typingNames << m_currentRoom->roomMembername(user);
     }
     m_currentlyTyping->setText( QString("<i>Currently typing: %1</i>").arg( typingNames.join(", ") ) );
 }

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -112,10 +112,8 @@ void MainWindow::connectionError(QString error)
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     if (connection)
-    {
-        disconnect( connection, &QMatrixClient::Connection::syncDone, this, &MainWindow::gotEvents );
-        disconnect( connection, &QMatrixClient::Connection::reconnected, this, &MainWindow::getNewEvents );
-    }
+        connection->disconnect( this ); // Disconnects all signals, not the connection itself
+
     event->accept();
 }
 

--- a/client/message.cpp
+++ b/client/message.cpp
@@ -22,21 +22,31 @@
 #include "lib/events/roommessageevent.h"
 #include "lib/user.h"
 #include "lib/connection.h"
+#include "lib/room.h"
 
-Message::Message(QMatrixClient::Connection* connection, QMatrixClient::Event* event)
+Message::Message(QMatrixClient::Connection* connection,
+                 QMatrixClient::Event* event,
+                 QMatrixClient::Room* room)
     : m_connection(connection)
     , m_event(event)
     , m_isHighlight(false)
     , m_isStatusMessage(true)
 {
-    if( event->type() == QMatrixClient::EventType::RoomMessage )
+    using namespace QMatrixClient;
+    if( event->type() == EventType::RoomMessage )
     {
         m_isStatusMessage = false;
-        QMatrixClient::RoomMessageEvent* messageEvent = static_cast<QMatrixClient::RoomMessageEvent*>(event);
-        QMatrixClient::User* user = m_connection->user();
-        if( messageEvent->body().contains(user->displayname()) or messageEvent->body().contains(user->id()) )
+        RoomMessageEvent* messageEvent = static_cast<RoomMessageEvent*>(event);
+        User* user = m_connection->user();
+        if( messageEvent->body().contains(user->id()) )
         {
             m_isHighlight = true;
+        }
+        if (room)
+        {
+            QString ownDisplayname = room->roomMembername(user);
+            if (messageEvent->body().contains(ownDisplayname))
+                m_isHighlight = true;
         }
     }
 }

--- a/client/message.h
+++ b/client/message.h
@@ -25,12 +25,15 @@ namespace QMatrixClient
 {
     class Connection;
     class Event;
+    class Room;
 }
 
 class Message
 {
     public:
-        Message(QMatrixClient::Connection* connection, QMatrixClient::Event* event);
+        Message(QMatrixClient::Connection* connection,
+                QMatrixClient::Event* event,
+                QMatrixClient::Room* room);
         virtual ~Message();
 
         QMatrixClient::Event* event();

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -46,9 +46,8 @@ void MessageEventModel::changeRoom(QMatrixClient::Room* room)
 {
     beginResetModel();
     if( m_currentRoom )
-    {
-        disconnect( m_currentRoom, &QuaternionRoom::newMessage, this, &MessageEventModel::newMessage );
-    }
+        m_currentRoom->disconnect( this );
+
     if( room )
     {
         m_currentRoom = static_cast<QuaternionRoom*>(room);

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -157,7 +157,8 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
         if( event->type() == QMatrixClient::EventType::RoomMessage )
         {
             QMatrixClient::RoomMessageEvent* e = static_cast<QMatrixClient::RoomMessageEvent*>(event);
-            return m_connection->user(e->userId())->displayname();
+            return m_currentRoom->roomMembername(
+                        m_connection->user(e->userId()));
         }
         return QVariant();
     }

--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -68,7 +68,7 @@ void RoomListModel::doAddRoom(QMatrixClient::Room* r)
     QuaternionRoom* room = static_cast<QuaternionRoom*>(r);
     m_rooms.append(room);
     connect( room, &QuaternionRoom::displaynameChanged,
-        this, &RoomListModel::namesChanged );
+        this, &RoomListModel::displaynameChanged );
     connect( room, &QuaternionRoom::unreadMessagesChanged,
         this, &RoomListModel::unreadMessagesChanged );
     connect( room, &QuaternionRoom::notificationCountChanged,
@@ -108,7 +108,7 @@ QVariant RoomListModel::data(const QModelIndex& index, int role) const
     return QVariant();
 }
 
-void RoomListModel::namesChanged(QMatrixClient::Room* room)
+void RoomListModel::displaynameChanged(QMatrixClient::Room* room)
 {
     int row = m_rooms.indexOf(static_cast<QuaternionRoom*>(room));
     emit dataChanged(index(row), index(row));

--- a/client/models/roomlistmodel.h
+++ b/client/models/roomlistmodel.h
@@ -43,7 +43,7 @@ class RoomListModel: public QAbstractListModel
         int rowCount(const QModelIndex& parent=QModelIndex()) const override;
 
     private slots:
-        void namesChanged(QMatrixClient::Room* room);
+        void displaynameChanged(QMatrixClient::Room* room);
         void unreadMessagesChanged(QMatrixClient::Room* room);
         void addRoom(QMatrixClient::Room* room);
 

--- a/client/models/roomlistmodel.h
+++ b/client/models/roomlistmodel.h
@@ -50,6 +50,8 @@ class RoomListModel: public QAbstractListModel
     private:
         QMatrixClient::Connection* m_connection;
         QList<QuaternionRoom*> m_rooms;
+
+        void doAddRoom(QMatrixClient::Room* r);
 };
 
 #endif // ROOMLISTMODEL_H

--- a/client/models/userlistmodel.cpp
+++ b/client/models/userlistmodel.cpp
@@ -47,12 +47,9 @@ void UserListModel::setRoom(QMatrixClient::Room* room)
     beginResetModel();
     if( m_currentRoom )
     {
-        disconnect( m_currentRoom, &QMatrixClient::Room::userAdded, this, &UserListModel::userAdded );
-        disconnect( m_currentRoom, &QMatrixClient::Room::userRemoved, this, &UserListModel::userRemoved );
+        m_currentRoom->disconnect( this );
         for( QMatrixClient::User* user: m_users )
-        {
-            disconnect( user, &QMatrixClient::User::avatarChanged, this, &UserListModel::avatarChanged );
-        }
+            user->disconnect( this );
         m_users.clear();
     }
     m_currentRoom = room;

--- a/client/models/userlistmodel.h
+++ b/client/models/userlistmodel.h
@@ -44,8 +44,7 @@ class UserListModel: public QAbstractListModel
     private slots:
         void userAdded(QMatrixClient::User* user);
         void userRemoved(QMatrixClient::User* user);
-
-    private slots:
+        void memberRenamed(QMatrixClient::User* user);
         void avatarChanged(QMatrixClient::User* user);
 
     private:

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -71,7 +71,7 @@ void QuaternionRoom::processMessageEvent(QMatrixClient::Event* event)
     bool isNewest = messageEvents().empty() || event->timestamp() > messageEvents().last()->timestamp();
     QMatrixClient::Room::processMessageEvent(event);
 
-    Message* message = new Message(connection(), event);
+    Message* message = new Message(connection(), event, this);
     for( int i=0; i<m_messages.count(); i++ )
     {
         if( message->timestamp() < m_messages.at(i)->timestamp() )
@@ -93,7 +93,7 @@ void QuaternionRoom::processMessageEvent(QMatrixClient::Event* event)
     {
         m_unreadMessages = true;
         emit unreadMessagesChanged(this);
-        qDebug() << displayName() << "unread messages";
+        qDebug() << "Room" << displayName() << ": unread messages";
     }
 }
 


### PR DESCRIPTION
This uses the code from [the respective PR in the libqmatrixclient](https://github.com/Fxrh/libqmatrixclient/pull/4) to render user and room names according to the spec. I also threw in some more deduplication/cleanup stuff. Compared to the lib, it's very straightforward here.