### PR TITLE
Improved UX during login, cleanup of orphaned connections & select able room topics

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -73,6 +73,8 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     m_currentlyTyping = new QLabel();
     m_topicLabel = new QLabel();
     m_topicLabel->setWordWrap(true);
+    m_topicLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
 
     QVBoxLayout* layout = new QVBoxLayout();
     layout->addWidget(m_topicLabel);

--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -59,6 +59,7 @@ QuaternionConnection* LoginDialog::connection() const
 void LoginDialog::login()
 {
     qDebug() << "login";
+    setDisabled(true);
     QUrl url = QUrl::fromUserInput(serverEdit->text());
     QString user = userEdit->text();
     QString password = passwordEdit->text();
@@ -71,4 +72,12 @@ void LoginDialog::login()
 void LoginDialog::error(QString error)
 {
     sessionLabel->setText( error );
+    setDisabled(false);
+}
+
+void LoginDialog::setDisabled(bool state) {
+    QDialog::setDisabled(state);
+    serverEdit->setDisabled(state);
+    userEdit->setDisabled(state);
+    loginButton->setDisabled(state);
 }

--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -27,7 +27,7 @@
 LoginDialog::LoginDialog(QWidget* parent)
     : QDialog(parent)
 {
-    m_connection = 0;
+    m_connection = nullptr;
     
     serverEdit = new QLineEdit("https://matrix.org");
     userEdit = new QLineEdit();
@@ -63,7 +63,9 @@ void LoginDialog::login()
     QUrl url = QUrl::fromUserInput(serverEdit->text());
     QString user = userEdit->text();
     QString password = passwordEdit->text();
-    m_connection = new QuaternionConnection(url);
+
+    setConnection(new QuaternionConnection(url));
+
     connect( m_connection, &QMatrixClient::Connection::connected, this, &QDialog::accept );
     connect( m_connection, &QMatrixClient::Connection::loginError, this, &LoginDialog::error );
     m_connection->connectToServer(user, password);
@@ -80,4 +82,14 @@ void LoginDialog::setDisabled(bool state) {
     serverEdit->setDisabled(state);
     userEdit->setDisabled(state);
     loginButton->setDisabled(state);
+}
+
+void LoginDialog::setConnection(QuaternionConnection* connection) {
+    emit connectionChanged(connection);
+
+    if (m_connection != nullptr) {
+        delete m_connection;
+    }
+
+    m_connection = connection;
 }

--- a/client/logindialog.h
+++ b/client/logindialog.h
@@ -36,6 +36,10 @@ class LoginDialog : public QDialog
 
         QuaternionConnection* connection() const;
         void setDisabled(bool state);
+        void setConnection(QuaternionConnection* connection);
+
+    signals:
+        void connectionChanged(QuaternionConnection* connection);
 
     private slots:
         void login();

--- a/client/logindialog.h
+++ b/client/logindialog.h
@@ -35,7 +35,8 @@ class LoginDialog : public QDialog
         LoginDialog(QWidget* parent=0);
 
         QuaternionConnection* connection() const;
-        
+        void setDisabled(bool state);
+
     private slots:
         void login();
         void error(QString error);

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -81,9 +81,7 @@ void MainWindow::initialize()
     setMenuBar(menuBar);
 
     LoginDialog dialog(this);
-    if( dialog.exec() )
-    {
-        connection = dialog.connection();
+    connect(&dialog, &LoginDialog::connectionChanged, [=](QuaternionConnection* connection){
         chatRoomWidget->setConnection(connection);
         userListDock->setConnection(connection);
         roomListDock->setConnection(connection);
@@ -91,6 +89,11 @@ void MainWindow::initialize()
         connect( connection, &QMatrixClient::Connection::connectionError, this, &MainWindow::connectionError );
         connect( connection, &QMatrixClient::Connection::syncDone, this, &MainWindow::gotEvents );
         connect( connection, &QMatrixClient::Connection::reconnected, this, &MainWindow::getNewEvents );
+    });
+
+    if( dialog.exec() )
+    {
+        connection = dialog.connection();
         connection->sync();
     }
 }


### PR DESCRIPTION
These three commits change some UX issues and cleanup old connections from previous connect attempts.

The Login dialog should not just freeze while connecting. It should reflect the processing state and avoid further login from the user.

When logging in with invalid user/password/server the old connection was never cleaned up. At the same time I've added a new signal to bounce information about a new connection to all involved components. This will be more useful once I can add the StatusBar commit (requires the Connection::syncStarted signal in libqmatrixclient).

Finally the topic of a channel should be select able. People can now copy&paste it somewhere else and at least open URIs until there is proper support.