### PR TITLE
Fixed a failing assert inside QList<> when syncing a room with no messages

### DIFF
--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -27,7 +27,7 @@ QuaternionRoom::QuaternionRoom(QMatrixClient::Connection* connection, QString ro
     : QMatrixClient::Room(connection, roomId)
 {
     m_shown = false;
-    m_unreadMessages = true;
+    m_unreadMessages = false;
     connect( this, &QuaternionRoom::notificationCountChanged, this, &QuaternionRoom::countChanged );
     connect( this, &QuaternionRoom::highlightCountChanged, this, &QuaternionRoom::countChanged );
 }
@@ -95,7 +95,8 @@ void QuaternionRoom::processEphemeralEvent(QMatrixClient::Event* event)
 {
     QMatrixClient::Room::processEphemeralEvent(event);
     QString lastReadId = lastReadEvent(connection()->user());
-    if( m_unreadMessages && lastReadId == messageEvents().last()->id() )
+    if( m_unreadMessages &&
+            (messageEvents().isEmpty() || lastReadId == messageEvents().last()->id()) )
     {
         m_unreadMessages = false;
         emit unreadMessagesChanged(this);


### PR DESCRIPTION
I caused this crash in a bit unfair way - by setting the number of timeline events in the filter down to zero. However, the case is valid: right now QuaternionRoom initializes unread messages flag with `true` even though there are no _any_ message events (yet). Probably there is a more profound fix that makes sure the flag and the container are consistent but this is the simplest fix that can be done in no time.