### PR TITLE
More guards against null Connection* members

### DIFF
--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -92,7 +92,7 @@ int MessageEventModel::rowCount(const QModelIndex& parent) const
 
 QVariant MessageEventModel::data(const QModelIndex& index, int role) const
 {
-    if( index.row() < 0 || index.row() >= m_currentMessages.count() )
+    if( index.row() < 0 || index.row() >= m_currentMessages.count() || !m_connection )
         return QVariant();
 
     Message* message = m_currentMessages.at(index.row());;

--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -39,6 +39,9 @@ RoomListModel::~RoomListModel()
 
 void RoomListModel::setConnection(QMatrixClient::Connection* connection)
 {
+    if (m_connection == connection)
+        return;
+
     beginResetModel();
     for( QuaternionRoom* room: m_rooms )
         room->disconnect( this );
@@ -46,9 +49,12 @@ void RoomListModel::setConnection(QMatrixClient::Connection* connection)
     m_rooms.clear();
 
     m_connection = connection;
-    connect( connection, &QMatrixClient::Connection::newRoom, this, &RoomListModel::addRoom );
-    for( QMatrixClient::Room* r: connection->roomMap() )
-        doAddRoom(r);
+    if (m_connection)
+    {
+        connect( m_connection, &QMatrixClient::Connection::newRoom, this, &RoomListModel::addRoom );
+        for( QMatrixClient::Room* r: m_connection->roomMap() )
+            doAddRoom(r);
+    }
 
     endResetModel();
 }

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -87,6 +87,9 @@ void RoomListDock::showContextMenu(const QPoint& pos)
 
 void RoomListDock::menuJoinSelected()
 {
+    if (!connection)
+        return;
+
     QModelIndex index = view->currentIndex();
     QuaternionRoom* room = model->roomAt(index.row());
     connection->joinRoom(room->id());
@@ -94,6 +97,9 @@ void RoomListDock::menuJoinSelected()
 
 void RoomListDock::menuLeaveSelected()
 {
+    if (!connection)
+        return;
+
     QModelIndex index = view->currentIndex();
     if( !index.isValid() )
         return;


### PR DESCRIPTION
When a logout action is introduced, we won't be able to rely on the fact that a Connection always exists.

A bit unobvious change is in imageprovider.cpp. The idea is that we have to check m_connection immediately before using it, rather than before dispatching a method call through an event loop, which can take a considerable time and lose the pointer to Connection along the way.