### PR TITLE
More chat widget love

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -147,7 +147,8 @@ void ChatRoomWidget::topicChanged()
 
 void ChatRoomWidget::getPreviousContent()
 {
-    m_currentRoom->getPreviousContent();
+    if (m_currentRoom)
+        m_currentRoom->getPreviousContent();
 }
 
 void ChatRoomWidget::sendLine()

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -244,17 +244,9 @@ void MessageEventModel::newMessage(Message* message)
     {
         return;
     }
-    for( int i=0; i<m_currentMessages.count(); i++ )
-    {
-        if( message->timestamp() < m_currentMessages.at(i)->timestamp() )
-        {
-            beginInsertRows(QModelIndex(), i, i);
-            m_currentMessages.insert(i, message);
-            endInsertRows();
-            return;
-        }
-    }
-    beginInsertRows(QModelIndex(), m_currentMessages.count(), m_currentMessages.count());
-    m_currentMessages.append(message);
+    auto pos = std::distance(m_currentMessages.begin(),
+            QMatrixClient::findInsertionPos(m_currentMessages, message));
+    beginInsertRows(QModelIndex(), pos, pos);
+    m_currentMessages.insert(pos, message);
     endInsertRows();
 }

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -47,9 +47,12 @@ Rectangle {
 
             section {
                 property: "date"
+                labelPositioning: ViewSection.InlineLabels | ViewSection.CurrentLabelAtStart
+
                 delegate: Rectangle {
                     width:parent.width
                     height: childrenRect.height
+                    color: "lightgrey"
                     Label { text: section.toLocaleString("dd.MM.yyyy") }
                 }
             }

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -92,8 +92,8 @@ Rectangle {
             }
             Rectangle {
                 color: highlight ? "orange" : "white"
-                height: contentField.height + imageField.height
-                width: parent.width - (x - parent.x) - spacing
+                height: contentField.height + imageField.height + sourceField.height
+                width: parent.width - (x - parent.x) - contextMenuButton.width - spacing
                 TextEdit {
                     id: contentField
                     selectByMouse: true; readOnly: true; font: timelabel.font;
@@ -102,14 +102,18 @@ Rectangle {
                     color: if( eventType == "other" ) { "darkgrey" }
                            else if( eventType == "emote" ) { "darkblue" }
                            else { "black" }
-                    ToolTipArea {
-                        tip { text: toolTip; color: "#999999"; zParent: message }
-                        enabled: debug
-                    }
+                }
+                TextEdit {
+                    id: sourceField
+                    selectByMouse: true; readOnly: true; font.family: "Monospace"
+                    text: toolTip
+                    anchors.top: contentField.bottom
+                    visible: showSource.checked
+                    height: visible ? implicitHeight : 0
                 }
                 Image {
                     id: imageField
-                    anchors.top: contentField.bottom
+                    anchors.top: sourceField.bottom
                     fillMode: Image.PreserveAspectFit
                     width: eventType == "image" ? parent.width : 0
                     sourceSize.width: eventType == "image" ? 500 : 0
@@ -117,6 +121,19 @@ Rectangle {
                     source: eventType == "image" ? content : ""
                 }
             }
+            ToolButton {
+                id: contextMenuButton
+                text: " "
+
+                menu: Menu {
+                    MenuItem {
+                        id: showSource
+                        checkable: true
+                        text: "View source"
+                    }
+                }
+            }
+
             spacing: 3
         }
     }

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -77,7 +77,7 @@ Rectangle {
 
             Label {
                 id: timelabel
-                text: time.toLocaleString(Qt.locale("de_DE"), "'<'hh:mm:ss'>'")
+                text: "<" + time.toLocaleTimeString() + ">"
                 color: "grey"
             }
             Label {

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -93,7 +93,7 @@ Rectangle {
             Rectangle {
                 color: highlight ? "orange" : "white"
                 height: contentField.height + imageField.height + sourceField.height
-                width: parent.width - (x - parent.x) - contextMenuButton.width - spacing
+                width: parent.width - (x - parent.x) - showSourceButton.width - spacing
                 TextEdit {
                     id: contentField
                     selectByMouse: true; readOnly: true; font: timelabel.font;
@@ -122,15 +122,14 @@ Rectangle {
                 }
             }
             ToolButton {
-                id: contextMenuButton
-                text: " "
+                id: showSourceButton
+                text: "..."
 
-                menu: Menu {
-                    MenuItem {
-                        id: showSource
-                        checkable: true
-                        text: "View source"
-                    }
+                action: Action {
+                    id: showSource
+
+                    tooltip: "Show source"
+                    checkable: true
                 }
             }
 

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -95,21 +95,23 @@ Rectangle {
                 height: contentField.height + imageField.height
                 width: parent.width - (x - parent.x) - spacing
                 TextEdit {
-                        id: contentField
-                        selectByMouse: true; readOnly: true; font: timelabel.font;
-                        text: content
-                        wrapMode: Text.Wrap; width: parent.width
-                        color: if( eventType == "other" ) { "darkgrey" }
-                               else if( eventType == "emote" ) { "darkblue" }
-                               else { "black" }
-                        ToolTipArea {
-                            tip { text: toolTip; color: "#999999"; zParent: message }
-                            enabled: debug
-                        }
+                    id: contentField
+                    selectByMouse: true; readOnly: true; font: timelabel.font;
+                    text: content
+                    wrapMode: Text.Wrap; width: parent.width
+                    color: if( eventType == "other" ) { "darkgrey" }
+                           else if( eventType == "emote" ) { "darkblue" }
+                           else { "black" }
+                    ToolTipArea {
+                        tip { text: toolTip; color: "#999999"; zParent: message }
+                        enabled: debug
+                    }
                 }
                 Image {
                     id: imageField
                     anchors.top: contentField.bottom
+                    fillMode: Image.PreserveAspectFit
+                    width: eventType == "image" ? parent.width : 0
                     sourceSize.width: eventType == "image" ? 500 : 0
                     sourceSize.height: eventType == "image" ? 500 : 0
                     source: eventType == "image" ? content : ""


### PR DESCRIPTION
An assorted set of tweaks and small fixes. On a visual side - images now fit the viewport and date sections now have background and stick to the top of the chat.
This does not enable rich text (yet) - a separate PR will come for that.