### PR TITLE
Rich text in timeline

### DIFF
--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -31,6 +31,7 @@
 #include "lib/events/roommessageevent.h"
 #include "lib/events/roommemberevent.h"
 #include "lib/events/roomaliasesevent.h"
+#include "lib/events/roomtopicevent.h"
 #include "lib/events/unknownevent.h"
 
 MessageEventModel::MessageEventModel(QObject* parent)
@@ -250,8 +251,14 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
         }
         if( event->type() == EventType::RoomAliases )
         {
-            RoomAliasesEvent* e = static_cast<RoomAliasesEvent*>(event);
+            auto e = static_cast<RoomAliasesEvent*>(event);
             return QString("Current aliases: %1").arg(e->aliases().join(", "));
+        }
+        if( event->type() == EventType::RoomTopic )
+        {
+            auto e = static_cast<RoomTopicEvent*>(event);
+            return QString("%1 has set the topic to: %2")
+                    .arg(m_currentRoom->roomMembername(e->senderId()), e->topic());
         }
         return "Unknown Event";
     }

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -42,6 +42,7 @@ class MessageEventModel: public QAbstractListModel
             DateRole,
             AuthorRole,
             ContentRole,
+            ContentTypeRole,
             HighlightRole
         };
 

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -11,61 +11,82 @@ Rectangle {
         chatView.positionViewAtEnd();
     }
 
-    ScrollView {
-    anchors.fill: parent
+    ListView {
+        id: chatView
+        anchors.fill: parent
 
-        ListView {
-            id: chatView
-            anchors.fill: parent
-            //width: 200; height: 250
+        model: messageModel
+        delegate: messageDelegate
+        flickableDirection: Flickable.VerticalFlick
+        pixelAligned: true
+        property bool wasAtEndY: true
 
-            model: messageModel
-            delegate: messageDelegate
-            flickableDirection: Flickable.VerticalFlick
-            pixelAligned: true
-            property bool wasAtEndY: true
+        function aboutToBeInserted() {
+            wasAtEndY = atYEnd;
+            console.log("aboutToBeInserted! atYEnd=" + atYEnd);
+        }
 
-            function aboutToBeInserted() {
-                wasAtEndY = atYEnd;
-                console.log("aboutToBeInserted! atYEnd=" + atYEnd);
+        function rowsInserted() {
+            if( wasAtEndY )
+            {
+                root.scrollToBottom();
+            } else  {
+                console.log("was not at end, not scrolling");
+            }
+        }
+
+        Component.onCompleted: {
+            console.log("onCompleted");
+            model.rowsAboutToBeInserted.connect(aboutToBeInserted);
+            model.rowsInserted.connect(rowsInserted);
+            //positionViewAtEnd();
+        }
+
+        section {
+            property: "date"
+            labelPositioning: ViewSection.InlineLabels | ViewSection.CurrentLabelAtStart
+
+            delegate: Rectangle {
+                width:parent.width
+                height: childrenRect.height
+                color: "lightgrey"
+                Label { text: section.toLocaleString("dd.MM.yyyy") }
+            }
+        }
+
+        onContentYChanged: {
+            if( (this.contentY - this.originY) < 5 )
+            {
+                console.log("get older content!");
+                root.getPreviousContent()
             }
 
-            function rowsInserted() {
-                if( wasAtEndY )
-                {
-                    root.scrollToBottom();
-                } else  {
-                    console.log("was not at end, not scrolling");
-                }
-            }
+        }
+    }
 
-            Component.onCompleted: {
-                console.log("onCompleted");
-                model.rowsAboutToBeInserted.connect(aboutToBeInserted);
-                model.rowsInserted.connect(rowsInserted);
-                //positionViewAtEnd();
-            }
+    Slider {
+        id: chatViewScroller
+        anchors.horizontalCenter: chatView.right
+        anchors.top: chatView.top
+        anchors.bottom: chatView.bottom
+        orientation: Qt.Vertical
+        maximumValue: 10.0
+        minimumValue: -10.0
+        activeFocusOnPress: false
+        activeFocusOnTab: false
 
-            section {
-                property: "date"
-                labelPositioning: ViewSection.InlineLabels | ViewSection.CurrentLabelAtStart
+        onPressedChanged: {
+            if (!pressed)
+                value = 0
+        }
 
-                delegate: Rectangle {
-                    width:parent.width
-                    height: childrenRect.height
-                    color: "lightgrey"
-                    Label { text: section.toLocaleString("dd.MM.yyyy") }
-                }
-            }
-
-            onContentYChanged: {
-                if( (this.contentY - this.originY) < 5 )
-                {
-                    console.log("get older content!");
-                    root.getPreviousContent()
-                }
-
-            }
+        onValueChanged: {
+            if (value)
+                chatView.flick(0, chatView.height * value)
+        }
+        Component.onCompleted: {
+            // This will cause continuous scrolling while the scroller is out of 0
+            chatView.flickEnded.connect(chatViewScroller.valueChanged)
         }
     }
 

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Controls 1.0
+import QtQuick.Layouts 1.1
 
 Rectangle {
     id: root
@@ -71,17 +72,21 @@ Rectangle {
     Component {
         id: messageDelegate
 
-        Row {
+        RowLayout {
             id: message
             width: parent.width
+            spacing: 3
 
             Label {
+                Layout.alignment: Qt.AlignTop
                 id: timelabel
                 text: "<" + time.toLocaleTimeString() + ">"
                 color: "grey"
             }
             Label {
-                width: 120; elide: Text.ElideRight;
+                Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+                Layout.preferredWidth: 120
+                elide: Text.ElideRight
                 text: eventType == "message" || eventType == "image" ? author : "***"
                 horizontalAlignment: if( eventType == "other" || eventType == "emote" )
                                      { Text.AlignRight }
@@ -92,38 +97,44 @@ Rectangle {
             }
             Rectangle {
                 color: highlight ? "orange" : "white"
-                height: contentField.height + imageField.height + sourceField.height
-                width: parent.width - (x - parent.x) - showSourceButton.width - spacing
-                TextEdit {
-                    id: contentField
-                    selectByMouse: true; readOnly: true; font: timelabel.font;
-                    text: content
-                    wrapMode: Text.Wrap; width: parent.width
-                    color: if( eventType == "other" ) { "darkgrey" }
-                           else if( eventType == "emote" ) { "darkblue" }
-                           else { "black" }
-                }
-                TextEdit {
-                    id: sourceField
-                    selectByMouse: true; readOnly: true; font.family: "Monospace"
-                    text: toolTip
-                    anchors.top: contentField.bottom
-                    visible: showSource.checked
-                    height: visible ? implicitHeight : 0
-                }
-                Image {
-                    id: imageField
-                    anchors.top: sourceField.bottom
-                    fillMode: Image.PreserveAspectFit
-                    width: eventType == "image" ? parent.width : 0
-                    sourceSize.width: eventType == "image" ? 500 : 0
-                    sourceSize.height: eventType == "image" ? 500 : 0
-                    source: eventType == "image" ? content : ""
+                Layout.fillWidth: true
+                Layout.minimumHeight: childrenRect.height
+
+                Column {
+                    spacing: 0
+                    width: parent.width
+
+                    TextEdit {
+                        id: contentField
+                        selectByMouse: true; readOnly: true; font: timelabel.font;
+                        text: content
+                        height: eventType == "image" ? 0 : implicitHeight
+                        wrapMode: Text.Wrap; width: parent.width
+                        color: if( eventType == "other" ) { "darkgrey" }
+                               else if( eventType == "emote" ) { "darkblue" }
+                               else { "black" }
+                    }
+                    TextArea {
+                        id: sourceField
+                        selectByMouse: true; readOnly: true; font.family: "Monospace"
+                        text: toolTip
+                        visible: showSource.checked
+                        width: parent.width
+                    }
+                    Image {
+                        id: imageField
+                        fillMode: Image.PreserveAspectFit
+                        width: eventType == "image" ? parent.width : 0
+
+                        sourceSize: eventType == "image" ? "500x500" : "0x0"
+                        source: eventType == "image" ? content : ""
+                    }
                 }
             }
             ToolButton {
                 id: showSourceButton
                 text: "..."
+                Layout.alignment: Qt.AlignTop
 
                 action: Action {
                     id: showSource
@@ -132,8 +143,6 @@ Rectangle {
                     checkable: true
                 }
             }
-
-            spacing: 3
         }
     }
 }

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -135,12 +135,13 @@ Rectangle {
                                else if( eventType == "emote" ) { "darkblue" }
                                else { "black" }
                     }
-                    TextArea {
-                        id: sourceField
-                        selectByMouse: true; readOnly: true; font.family: "Monospace"
-                        text: toolTip
-                        visible: showSource.checked
+                    Loader {
+                        asynchronous: true
+                        visible: status == Loader.Ready
                         width: parent.width
+                        property string sourceText: toolTip
+
+                        sourceComponent: showSource.checked ? sourceArea : undefined
                     }
                     Image {
                         id: imageField
@@ -164,6 +165,15 @@ Rectangle {
                     checkable: true
                 }
             }
+        }
+    }
+
+    Component {
+        id: sourceArea
+
+        TextArea {
+            selectByMouse: true; readOnly: true; font.family: "Monospace"
+            text: sourceText
         }
     }
 }

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -18,6 +18,7 @@ Rectangle {
         model: messageModel
         delegate: messageDelegate
         flickableDirection: Flickable.VerticalFlick
+        boundsBehavior: Flickable.StopAtBounds
         pixelAligned: true
         property bool wasAtEndY: true
 
@@ -66,12 +67,15 @@ Rectangle {
 
     Slider {
         id: chatViewScroller
-        anchors.horizontalCenter: chatView.right
-        anchors.top: chatView.top
-        anchors.bottom: chatView.bottom
         orientation: Qt.Vertical
+        anchors.horizontalCenter: chatView.right
+        anchors.verticalCenter: chatView.verticalCenter
+        height: chatView.height / 2
+
+        value: -chatView.verticalVelocity / chatView.height
         maximumValue: 10.0
         minimumValue: -10.0
+
         activeFocusOnPress: false
         activeFocusOnTab: false
 
@@ -81,7 +85,7 @@ Rectangle {
         }
 
         onValueChanged: {
-            if (value)
+            if (pressed && value)
                 chatView.flick(0, chatView.height * value)
         }
         Component.onCompleted: {

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.2
 import QtQuick.Controls 1.0
 import QtQuick.Layouts 1.1
 
@@ -112,7 +112,10 @@ Rectangle {
                 Layout.alignment: Qt.AlignTop | Qt.AlignLeft
                 Layout.preferredWidth: 120
                 elide: Text.ElideRight
-                text: eventType == "message" || eventType == "image" ? author : "***"
+                text: eventType == "message" ||
+                      eventType == "image" ||
+                      eventType == "emote"
+                      ? author : "***"
                 horizontalAlignment: if( eventType == "other" || eventType == "emote" )
                                      { Text.AlignRight }
                 color: if( eventType == "other" ) { "darkgrey" }
@@ -124,6 +127,7 @@ Rectangle {
                 color: highlight ? "orange" : "white"
                 Layout.fillWidth: true
                 Layout.minimumHeight: childrenRect.height
+                Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
                 Column {
                     spacing: 0
@@ -132,20 +136,23 @@ Rectangle {
                     TextEdit {
                         id: contentField
                         selectByMouse: true; readOnly: true; font: timelabel.font;
-                        text: content
-                        height: eventType == "image" ? 0 : implicitHeight
+                        textFormat: contentType == "text/html" ? TextEdit.RichText
+                                                               : TextEdit.PlainText;
+                        text: eventType != "image" ? content : ""
+                        height: eventType != "image" ? implicitHeight : 0
                         wrapMode: Text.Wrap; width: parent.width
                         color: if( eventType == "other" ) { "darkgrey" }
                                else if( eventType == "emote" ) { "darkblue" }
                                else { "black" }
-                    }
-                    Loader {
-                        asynchronous: true
-                        visible: status == Loader.Ready
-                        width: parent.width
-                        property string sourceText: toolTip
 
-                        sourceComponent: showSource.checked ? sourceArea : undefined
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
+                            acceptedButtons: Qt.NoButton
+                        }
+                        onLinkActivated: {
+                            Qt.openUrlExternally(link)
+                        }
                     }
                     Image {
                         id: imageField
@@ -154,6 +161,14 @@ Rectangle {
 
                         sourceSize: eventType == "image" ? "500x500" : "0x0"
                         source: eventType == "image" ? content : ""
+                    }
+                    Loader {
+                        asynchronous: true
+                        visible: status == Loader.Ready
+                        width: parent.width
+                        property string sourceText: toolTip
+
+                        sourceComponent: showSource.checked ? sourceArea : undefined
                     }
                 }
             }


### PR DESCRIPTION
This relies on the previous PR(#43) - the new commits are actually just two most recent ones. Most prominently, this adds support of HTML messages (in particular, those produced by Vector). Because emotes can be HTML-based too, I changed the way they are rendered - it looks a bit unusual (definitely not weechat-like) so I really want your feedback on this. If you don't like it, I can do another commit to include the room member name into the content.
Also, as a bonus, comes proper rendering of topic events inside the timeline.