### PR TITLE
Set CMAKE_BUILD_TYPE if none is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,16 @@ if(UNIX AND NOT APPLE)
     set(LINUX 1)
 endif(UNIX AND NOT APPLE)
 
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Debug' as none was specified")
+  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build" FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "MinSizeRel" "RelWithDebInfo")
+endif()
+
 # Find the libraries
 find_package(Qt5Widgets 5.2.1)
 find_package(Qt5Network 5.2.1)


### PR DESCRIPTION
While searching for a best way to "install" CMake projects on Windows, I stumbled upon this block, written by people from the same company that maintains CMake. I never understood why the "default" build type exists in CMake and it's anyway unused on build platforms that we use. As of now, it definitely makes sense to fallback to Debug.