### PR TITLE
Account settings and logout

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -119,6 +119,7 @@ void ChatRoomWidget::setRoom(QMatrixClient::Room* room)
 
 void ChatRoomWidget::setConnection(QMatrixClient::Connection* connection)
 {
+    setRoom(nullptr);
     m_currentConnection = connection;
     m_imageProvider->setConnection(connection);
     m_messageModel->setConnection(connection);

--- a/client/logindialog.h
+++ b/client/logindialog.h
@@ -21,12 +21,11 @@
 #define LOGINDIALOG_H
 
 #include <QtWidgets/QDialog>
-#include <QtWidgets/QLineEdit>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QHBoxLayout>
 
+class QLineEdit;
+class QPushButton;
+class QLabel;
+class QCheckBox;
 class QuaternionConnection;
 
 class LoginDialog : public QDialog
@@ -36,11 +35,7 @@ class LoginDialog : public QDialog
         LoginDialog(QWidget* parent = nullptr);
 
         QuaternionConnection* connection() const;
-        void setDisabled(bool state);
-        void setConnection(QuaternionConnection* connection);
-
-    signals:
-        void connectionChanged(QuaternionConnection* connection);
+        bool keepLoggedIn() const;
 
     private slots:
         void login();
@@ -52,8 +47,11 @@ class LoginDialog : public QDialog
         QLineEdit* passwordEdit;
         QPushButton* loginButton;
         QLabel* sessionLabel;
+        QCheckBox* saveTokenCheck;
         
         QuaternionConnection* m_connection;
+
+        void setConnection(QuaternionConnection* connection);
 };
 
 #endif // LOGINDIALOG_H

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -27,6 +27,7 @@
 int main( int argc, char* argv[] )
 {
     QApplication app(argc, argv);
+    QApplication::setOrganizationName("Quaternion");
     QApplication::setApplicationName("quaternion");
     QApplication::setApplicationDisplayName("Quaternion");
     QApplication::setApplicationVersion("0.0");
@@ -47,10 +48,6 @@ int main( int argc, char* argv[] )
     if( debugEnabled )
         window.enableDebug();
     window.show();
-
-    //LoginDialog dialog(&widget);
-    //QTimer::singleShot(0, &dialog, &QDialog::exec);
-    //dialog.exec();
 
     return app.exec();
 }

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -45,18 +45,22 @@ class MainWindow: public QMainWindow
 
         void enableDebug();
 
-    private slots:
-        void initialize();
-        void getNewEvents();
-        void gotEvents();
-
-        void connectionError(QString error);
+        void setConnection(QuaternionConnection* newConnection);
 
     protected:
         virtual void closeEvent(QCloseEvent* event) override;
 
     private slots:
+        void initialize();
+        void getNewEvents();
+        void gotEvents();
+        void loggedOut();
+
+        void connectionError(QString error);
+
         void showJoinRoomDialog();
+        void showLoginWindow();
+        void logout();
 
     private:
         RoomListDock* roomListDock;
@@ -64,14 +68,12 @@ class MainWindow: public QMainWindow
         ChatRoomWidget* chatRoomWidget;
         QuaternionConnection* connection;
 
-        QMenuBar* menuBar;
-        QMenu* connectionMenu;
-        QMenu* roomMenu;
-
-        QAction* quitAction;
-        QAction* joinRoomAction;
+        QAction* loginAction;
+        QAction* logoutAction;
 
         SystemTray* systemTray;
+
+        void invokeLogin();
 };
 
 #endif // MAINWINDOW_H

--- a/client/systemtray.cpp
+++ b/client/systemtray.cpp
@@ -36,7 +36,7 @@ void SystemTray::setConnection(QMatrixClient::Connection* connection)
 {
     if( m_connection )
     {
-        disconnect(m_connection, &QMatrixClient::Connection::newRoom, this, &SystemTray::newRoom);
+        m_connection->disconnect(this);
     }
     m_connection = connection;
     if( m_connection )


### PR DESCRIPTION
This brings in the following major things:
 - Storing account settings (homeserver, userid, access_token and keep_logged_in) using `QMatrixClient::AccountSettings`. This has been done with potential gaining of multiple accounts support in mind, so it's now a bit more generic than it needs for a single account. In particular, settings are stored under a separate group (keyed by a fully qualified userid) inside "Accounts" group. I also tried to write the code so that it would be easier to extend it on multiple accounts later on.
 - Automatic login upon starting the application, if access_token has been saved.
 - Logging out. This required removing all those race conditions due to syncJob's running independently almost at any point in time. Fortunately it came to be fairly easy, as soon as those syncJob's are explicitly abandoned. Active jobs prevent deleteLater() to actually delete an object, as it turned out - so a pure fire-and-forget at least for long-polling jobs is not quite workable, it seems. Note that, by debug logs, jobs still take their time to actually be destroyed; but since they are already disconnected and don't have active network connections underneath, they are pretty much benign.