### PR TITLE
Fix crash when clicking on logout while not logged in

### DIFF
--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -73,6 +73,7 @@ void MainWindow::initialize()
 
         logoutAction = connectionMenu->addAction(tr("&Logout"));
         connect( logoutAction, &QAction::triggered, this, &MainWindow::logout );
+        logoutAction->setEnabled(false); // we start in a logged out state
 
         connectionMenu->addSeparator();
 
@@ -169,6 +170,9 @@ void MainWindow::invokeLogin()
 
 void MainWindow::logout()
 {
+    if( !connection )
+        return; // already logged out
+
     QMatrixClient::AccountSettings account { connection->userId() };
     account.clearAccessToken();
     account.sync();


### PR DESCRIPTION
1.) Disable the logout menu entry on startup
2.) Don't try to log out if already logged out

This should fix issue #54 