### PR TITLE
Fix messages ordering

### DIFF
--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -56,7 +56,7 @@ class MessageEventModel: public QAbstractListModel
 
         //override QModelIndex index(int row, int column, const QModelIndex& parent=QModelIndex()) const;
         //override QModelIndex parent(const QModelIndex& index) const;
-        int rowCount(const QModelIndex& parent) const override;
+        int rowCount(const QModelIndex& parent = QModelIndex()) const override;
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
 

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -25,14 +25,7 @@
 #include <QtCore/QAbstractListModel>
 #include <QtCore/QModelIndex>
 
-namespace QMatrixClient
-{
-    class Room;
-    class Connection;
-}
-
 class Message;
-class QuaternionRoom;
 
 class MessageEventModel: public QAbstractListModel
 {
@@ -60,13 +53,9 @@ class MessageEventModel: public QAbstractListModel
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
 
-    public slots:
-        void newMessage(Message* messageEvent);
-
     private:
         QMatrixClient::Connection* m_connection;
         QuaternionRoom* m_currentRoom;
-        QList<Message*> m_currentMessages;
 };
 
 #endif // LOGMESSAGEMODEL_H

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -69,21 +69,22 @@ bool QuaternionRoom::hasUnreadMessages()
     return m_unreadMessages;
 }
 
-void QuaternionRoom::processMessageEvent(QMatrixClient::Event* event)
+inline Message* QuaternionRoom::makeMessage(QMatrixClient::Event* e)
 {
-    bool isNewest = messageEvents().empty() || event->timestamp() > messageEvents().last()->timestamp();
-    QMatrixClient::Room::processMessageEvent(event);
+    return new Message(connection(), e, this);
+}
 
-    Message* message = new Message(connection(), event, this);
-    m_messages.insert(QMatrixClient::findInsertionPos(m_messages, message), message);
+void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
+{
+    Room::doAddNewMessageEvents(events);
 
-    emit newMessage(message);
+    m_messages.reserve(m_messages.size() + events.size());
+    for (auto e: events)
+        m_messages.push_back(makeMessage(e));
 
-    if( !isNewest )
-        return;
     if( m_shown )
     {
-        markMessageAsRead(event);
+        markMessageAsRead(messageEvents().back());
     }
     else if( !m_unreadMessages )
     {
@@ -91,6 +92,16 @@ void QuaternionRoom::processMessageEvent(QMatrixClient::Event* event)
         emit unreadMessagesChanged(this);
         qDebug() << "Room" << displayName() << ": unread messages";
     }
+}
+
+void QuaternionRoom::doAddHistoricalMessageEvents(const QMatrixClient::Events& events)
+{
+    Room::doAddHistoricalMessageEvents(events);
+
+    m_messages.reserve(m_messages.size() + events.size());
+    for (auto e: events)
+        m_messages.push_back(makeMessage(e));
+    std::rotate(m_messages.begin(), m_messages.end() - events.size(), m_messages.end());
 }
 
 void QuaternionRoom::processEphemeralEvent(QMatrixClient::Event* event)

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -100,8 +100,7 @@ void QuaternionRoom::doAddHistoricalMessageEvents(const QMatrixClient::Events& e
 
     m_messages.reserve(m_messages.size() + events.size());
     for (auto e: events)
-        m_messages.push_back(makeMessage(e));
-    std::rotate(m_messages.begin(), m_messages.end() - events.size(), m_messages.end());
+        m_messages.push_front(makeMessage(e));
 }
 
 void QuaternionRoom::processEphemeralEvent(QMatrixClient::Event* event)

--- a/client/quaternionroom.h
+++ b/client/quaternionroom.h
@@ -29,6 +29,7 @@ class QuaternionRoom: public QMatrixClient::Room
         Q_OBJECT
     public:
         using Timeline = QList<Message*>;
+        using size_type = Timeline::size_type;
 
         QuaternionRoom(QMatrixClient::Connection* connection, QString roomId);
 
@@ -44,11 +45,13 @@ class QuaternionRoom: public QMatrixClient::Room
         bool hasUnreadMessages();
 
     signals:
-        void newMessage(Message* message);
+        void aboutToInsertMessages(size_type from, size_type to);
+        void insertedMessages();
         void unreadMessagesChanged(QuaternionRoom* room);
 
     protected:
-        virtual void processMessageEvent(QMatrixClient::Event* event) override;
+        virtual void doAddNewMessageEvents(const QMatrixClient::Events& events) override;
+        virtual void doAddHistoricalMessageEvents(const QMatrixClient::Events& events) override;
         virtual void processEphemeralEvent(QMatrixClient::Event* event) override;
 
     private slots:
@@ -58,6 +61,8 @@ class QuaternionRoom: public QMatrixClient::Room
         Timeline m_messages;
         bool m_shown;
         bool m_unreadMessages;
+
+        Message* makeMessage(QMatrixClient::Event* e);
 };
 
 #endif // QUATERNIONROOM_H


### PR DESCRIPTION
This accompanies Fxrh/libqmatrixclient#30. One notable thing not directly related to ordering is that `MessageEventModel` now uses the messages container of `QuaternionRoom` instead of maintaining its own copy.