### PR TITLE
Sort room member list

### DIFF
--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -22,9 +22,6 @@
 
 #include <QtWidgets/QMainWindow>
 
-#include "lib/room.h"
-#include "lib/jobs/basejob.h"
-
 class RoomListDock;
 class UserListDock;
 class ChatRoomWidget;

--- a/client/roomlistdock.h
+++ b/client/roomlistdock.h
@@ -24,7 +24,6 @@
 #include <QtWidgets/QListView>
 #include <QtCore/QStringListModel>
 
-#include "lib/room.h"
 #include "lib/connection.h"
 
 class RoomListModel;


### PR DESCRIPTION
That's a quick and simple implementation of room member list sorting. It boils down to a comparator class that is used every time when `UserListModel::m_users` is accessed. A more careful approach would be to imbue the `m_users`' type with self-sorting features but that implies much more keystrokes (though the same code will most likely be useful in other places of the application). I'll leave that kind of refactoring for another time (and apparently will make it in libqmatrixclient).
A note on `lowerBoundIndex`: I made it a template in order to unbind from a certain container type because `m_users` is a very good candidate for `QList`->`QVector` replacement. Needless to say it's only instantiated once.