### PR TITLE
Display tweaks

### DIFF
--- a/client/message.cpp
+++ b/client/message.cpp
@@ -40,7 +40,7 @@ Message::Message(QMatrixClient::Connection* connection,
         RoomMessageEvent* messageEvent = static_cast<RoomMessageEvent*>(event);
         User* localUser = m_connection->user();
         // Only highlight messages from other users
-        if (messageEvent->userId() != localUser->id())
+        if (messageEvent->senderId() != localUser->id())
         {
             if( messageEvent->body().contains(localUser->id()) )
             {

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -20,6 +20,7 @@
 #include "messageeventmodel.h"
 
 #include <QtCore/QStringBuilder>
+#include <QtCore/QSettings>
 #include <QtCore/QDebug>
 
 #include "../message.h"
@@ -285,6 +286,14 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
     if( role == HighlightRole )
     {
         return message->highlight();
+    }
+
+    if( role == Qt::DecorationRole )
+    {
+        if (message->highlight())
+        {
+            return QSettings().value("UI/highlight_color", "orange");
+        }
     }
     return QVariant();
 }

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -32,6 +32,7 @@
 #include "lib/events/roommemberevent.h"
 #include "lib/events/roomnameevent.h"
 #include "lib/events/roomaliasesevent.h"
+#include "lib/events/roomcanonicalaliasevent.h"
 #include "lib/events/roomtopicevent.h"
 #include "lib/events/unknownevent.h"
 
@@ -93,6 +94,8 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
 
     const Message* message = m_currentRoom->messages().at(index.row());;
     Event* event = message->messageEvent();
+    // FIXME: Rewind to the name that was at the time of this event
+    QString senderName = m_currentRoom->roomMembername(event->senderId());
 
     if( role == Qt::DisplayRole )
     {
@@ -134,16 +137,26 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
 
     if( role == EventTypeRole )
     {
-        if( event->type() == EventType::RoomMessage )
+        switch (event->type())
         {
-            auto msgType = static_cast<RoomMessageEvent*>(event)->msgtype();
-            if( msgType == MessageEventType::Image )
-                return "image";
-            else if( msgType == MessageEventType::Emote )
-                return "emote";
-            return "message";
+            case EventType::RoomMessage:
+            {
+                auto msgType = static_cast<RoomMessageEvent*>(event)->msgtype();
+                if( msgType == MessageEventType::Image )
+                    return "image";
+                else if( msgType == MessageEventType::Emote )
+                    return "emote";
+                return "message";
+            }
+            case EventType::RoomMember:
+            case EventType::RoomAliases:
+            case EventType::RoomCanonicalAlias:
+            case EventType::RoomName:
+            case EventType::RoomTopic:
+                return "state";
+            default:
+                return "other";
         }
-        return "other";
     }
 
     if( role == TimeRole )
@@ -158,12 +171,7 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
 
     if( role == AuthorRole )
     {
-        if( event->type() == EventType::RoomMessage )
-        {
-            RoomMessageEvent* e = static_cast<RoomMessageEvent*>(event);
-            return m_currentRoom->roomMembername(e->userId());
-        }
-        return QVariant();
+        return senderName;
     }
 
     if (role == ContentTypeRole  || role == ContentRole)
@@ -228,36 +236,48 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
         if( event->type() == EventType::RoomMember )
         {
             RoomMemberEvent* e = static_cast<RoomMemberEvent*>(event);
+            // FIXME: Rewind to the name that was at the time of this event
+            QString subjectName = m_currentRoom->roomMembername(e->userId());
+            // The below code assumes senderName output in AuthorRole
             switch( e->membership() )
             {
                 case MembershipType::Join:
-                    return QString("%1 (%2) joined the room").arg(e->displayName(), e->userId());
+                    return tr("joined the room");
                 case MembershipType::Leave:
-                    return QString("%1 (%2) left the room").arg(e->displayName(), e->userId());
+                    if (e->senderId() != e->userId())
+                        return tr("doesn't want %1 in the room anymore").arg(subjectName);
+                    else
+                        return tr("left the room");
                 case MembershipType::Ban:
-                    return QString("%1 (%2) was banned from the room").arg(e->displayName(), e->userId());
+                    if (e->senderId() != e->userId())
+                        return tr("banned %1 from the room").arg(subjectName);
+                    else
+                        return tr("self-banned from the room");
                 case MembershipType::Invite:
-                    return QString("%1 (%2) was invited to the room").arg(e->displayName(), e->userId());
+                    return tr("invited %1 to the room").arg(subjectName);
                 case MembershipType::Knock:
-                    return QString("%1 (%2) knocked").arg(e->displayName(), e->userId());
+                    return tr("knocked");
             }
         }
         if( event->type() == EventType::RoomAliases )
         {
             auto e = static_cast<RoomAliasesEvent*>(event);
-            return QString("Current aliases: %1").arg(e->aliases().join(", "));
+            return tr("set aliases to: %1").arg(e->aliases().join(", "));
+        }
+        if( event->type() == EventType::RoomCanonicalAlias )
+        {
+            auto e = static_cast<RoomCanonicalAliasEvent*>(event);
+            return tr("set the room main alias to: %1").arg(e->alias());
         }
         if( event->type() == EventType::RoomName )
         {
             auto e = static_cast<RoomNameEvent*>(event);
-            return QString("%1 has set the room name to: %2")
-                    .arg(m_currentRoom->roomMembername(e->senderId()), e->name());
+            return tr("set the room name to: %1").arg(e->name());
         }
         if( event->type() == EventType::RoomTopic )
         {
             auto e = static_cast<RoomTopicEvent*>(event);
-            return QString("%1 has set the topic to: %2")
-                    .arg(m_currentRoom->roomMembername(e->senderId()), e->topic());
+            return tr("set the topic to: %1").arg(e->topic());
         }
         return "Unknown Event";
     }

--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -107,14 +107,10 @@ QVariant RoomListModel::data(const QModelIndex& index, int role) const
     {
         return room->displayName();
     }
-    if( role == Qt::ForegroundRole )
-    {
-        if( room->highlightCount() > 0 )
-            return QBrush(QColor("orange"));
-        if( room->hasUnreadMessages() )
-            return QBrush(QColor("blue"));
-        return QVariant();
-    }
+    if( role == HasUnreadRole )
+        return room->hasUnreadMessages();
+    if( role == HighlightCountRole )
+        return room->highlightCount();
     if( role == Qt::DecorationRole )
     {
         switch( room->joinState() )

--- a/client/models/roomlistmodel.h
+++ b/client/models/roomlistmodel.h
@@ -34,6 +34,11 @@ class RoomListModel: public QAbstractListModel
 {
         Q_OBJECT
     public:
+        enum Roles {
+            HasUnreadRole = Qt::UserRole + 1,
+            HighlightCountRole,
+        };
+
         RoomListModel(QObject* parent = nullptr);
         virtual ~RoomListModel();
 

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -5,6 +5,11 @@ import QtQuick.Layouts 1.1
 Rectangle {
     id: root
 
+    SystemPalette { id: defaultPalette; colorGroup: SystemPalette.Active }
+    SystemPalette { id: disabledPalette; colorGroup: SystemPalette.Disabled }
+
+    color: defaultPalette.base
+
     signal getPreviousContent()
 
     function scrollToBottom() {
@@ -50,7 +55,7 @@ Rectangle {
             delegate: Rectangle {
                 width:parent.width
                 height: childrenRect.height
-                color: "lightgrey"
+                color: defaultPalette.window
                 Label { text: section.toLocaleString("dd.MM.yyyy") }
             }
         }
@@ -102,29 +107,32 @@ Rectangle {
             width: parent.width
             spacing: 3
 
+            property string textColor:
+                    // FIXME: Doesn't play well with monochrome colour schemes
+                    if (highlight) { defaultPalette.highlight }
+                    else if (eventType == "state" || eventType == "other") { disabledPalette.text }
+//                    else if (eventType == "emote") { defaultPalette.highlight }
+                    else { defaultPalette.text }
+
             Label {
                 Layout.alignment: Qt.AlignTop
                 id: timelabel
                 text: "<" + time.toLocaleTimeString() + ">"
-                color: "grey"
+                color: disabledPalette.text
             }
             Label {
                 Layout.alignment: Qt.AlignTop | Qt.AlignLeft
                 Layout.preferredWidth: 120
                 elide: Text.ElideRight
-                text: eventType == "message" ||
-                      eventType == "image" ||
-                      eventType == "emote"
-                      ? author : "***"
-                horizontalAlignment: if( eventType == "other" || eventType == "emote" )
+                text: eventType == "state" || eventType == "emote" ? "* " + author :
+                      eventType != "other" ? author : "***"
+                horizontalAlignment: if( ["other", "emote", "state"]
+                                             .indexOf(eventType) >= 0 )
                                      { Text.AlignRight }
-                color: if( eventType == "other" ) { "darkgrey" }
-                       else if( eventType == "emote" ) { "darkblue" }
-                       else { "black" }
-
+                color: message.textColor
             }
             Rectangle {
-                color: highlight ? "orange" : "white"
+                color: defaultPalette.base
                 Layout.fillWidth: true
                 Layout.minimumHeight: childrenRect.height
                 Layout.alignment: Qt.AlignTop | Qt.AlignLeft
@@ -141,9 +149,7 @@ Rectangle {
                         text: eventType != "image" ? content : ""
                         height: eventType != "image" ? implicitHeight : 0
                         wrapMode: Text.Wrap; width: parent.width
-                        color: if( eventType == "other" ) { "darkgrey" }
-                               else if( eventType == "emote" ) { "darkblue" }
-                               else { "black" }
+                        color: message.textColor
 
                         MouseArea {
                             anchors.fill: parent

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -108,11 +108,9 @@ Rectangle {
             spacing: 3
 
             property string textColor:
-                    // FIXME: Doesn't play well with monochrome colour schemes
-                    if (highlight) { defaultPalette.highlight }
-                    else if (eventType == "state" || eventType == "other") { disabledPalette.text }
-//                    else if (eventType == "emote") { defaultPalette.highlight }
-                    else { defaultPalette.text }
+                    if (highlight) decoration
+                    else if (eventType == "state" || eventType == "other") disabledPalette.text
+                    else defaultPalette.text
 
             Label {
                 Layout.alignment: Qt.AlignTop

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -29,7 +29,9 @@
 class RoomListItemDelegate : public QStyledItemDelegate
 {
     public:
-        using QStyledItemDelegate::QStyledItemDelegate;
+        explicit RoomListItemDelegate(QObject* parent = nullptr)
+            : QStyledItemDelegate(parent)
+        { }
 
         void paint(QPainter *painter, const QStyleOptionViewItem &option,
                    const QModelIndex &index) const override;

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -19,6 +19,7 @@
 
 #include "roomlistdock.h"
 
+#include <QtCore/QSettings>
 #include <QtCore/QDebug>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QStyledItemDelegate>
@@ -31,10 +32,16 @@ class RoomListItemDelegate : public QStyledItemDelegate
     public:
         explicit RoomListItemDelegate(QObject* parent = nullptr)
             : QStyledItemDelegate(parent)
+            , highlightColor(QSettings()
+                             .value("UI/highlight_color", QColor("orange"))
+                             .value<QColor>())
         { }
 
         void paint(QPainter *painter, const QStyleOptionViewItem &option,
                    const QModelIndex &index) const override;
+
+    private:
+        QColor highlightColor;
 };
 
 void RoomListItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
@@ -48,7 +55,7 @@ void RoomListItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& 
     {
         // Highlighting the text may not work out on monochrome colour schemes,
         // hence duplicating with italic font.
-        o.palette.setBrush(QPalette::Text, o.palette.brush(QPalette::Highlight));
+        o.palette.setColor(QPalette::Text, highlightColor);
         o.font.setItalic(true);
     }
 

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -21,19 +21,47 @@
 
 #include <QtCore/QDebug>
 #include <QtWidgets/QMenu>
+#include <QtWidgets/QStyledItemDelegate>
 
 #include "models/roomlistmodel.h"
 #include "quaternionroom.h"
+
+class RoomListItemDelegate : public QStyledItemDelegate
+{
+    public:
+        using QStyledItemDelegate::QStyledItemDelegate;
+
+        void paint(QPainter *painter, const QStyleOptionViewItem &option,
+                   const QModelIndex &index) const override;
+};
+
+void RoomListItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    QStyleOptionViewItem o { option };
+
+    if (index.data(RoomListModel::HasUnreadRole).toBool())
+        o.font.setBold(true);
+
+    if (index.data(RoomListModel::HighlightCountRole).toInt() > 0)
+    {
+        // Highlighting the text may not work out on monochrome colour schemes,
+        // hence duplicating with italic font.
+        o.palette.setBrush(QPalette::Text, o.palette.brush(QPalette::Highlight));
+        o.font.setItalic(true);
+    }
+
+    QStyledItemDelegate::paint(painter, o, index);
+}
 
 RoomListDock::RoomListDock(QWidget* parent)
     : QDockWidget("Rooms", parent)
     , connection(nullptr)
 {
     setObjectName("RoomsDock");
-    //setWidget(new QWidget());
     model = new RoomListModel(this);
     view = new QListView();
     view->setModel(model);
+    view->setItemDelegate(new RoomListItemDelegate(this));
     connect( view, &QListView::activated, this, &RoomListDock::rowSelected );
     connect( view, &QListView::clicked, this, &RoomListDock::rowSelected);
     setWidget(view);


### PR DESCRIPTION
Some highly visual improvements, so testing is very much welcome (weekend ahead :) ):
 - using sender to enhance status messages;
 - renames were in the previous commit, reflecting canonical aliases in the timeline now arrives;
 - most visual: instead of using specific colours I rewired both the timeline and the room list to something less intrusive into the desktop palette - users of dark themes are welcome.

The last change made Quaternion less colourful than it used to be; but I don't think this can be helped without breaking so colour schemas that can be so diverse. Feedback is much welcome though.