### PR TITLE
Don’t show timezone in chatwindow timestamps

### DIFF
--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -115,7 +115,7 @@ Rectangle {
             Label {
                 Layout.alignment: Qt.AlignTop
                 id: timelabel
-                text: "<" + time.toLocaleTimeString(Qt.locale(), "hh:mm:ss") + ">"
+                text: "<" + time.toLocaleTimeString(Qt.locale(), Locale.ShortFormat) + ">"
                 color: disabledPalette.text
             }
             Label {

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -115,7 +115,7 @@ Rectangle {
             Label {
                 Layout.alignment: Qt.AlignTop
                 id: timelabel
-                text: "<" + time.toLocaleTimeString() + ">"
+                text: "<" + time.toLocaleTimeString(Qt.locale(), "hh:mm:ss") + ">"
                 color: disabledPalette.text
             }
             Label {


### PR DESCRIPTION
Format is now. <hh:mm:ss>