### PR TITLE
Clear topic and typing notifications if room is unset

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -110,6 +110,9 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
         m_currentRoom->setShown(true);
         topicChanged();
         typingChanged();
+    } else {
+        m_topicLabel->clear();
+        m_currentlyTyping->clear();
     }
     m_messageModel->changeRoom( m_currentRoom );
     //m_messageView->scrollToBottom();


### PR DESCRIPTION
This should fix #81. Sorry for double PR.

But I am a bit confused by the behaviour. When the Topic is cleared, the topic label disappears or collapses. Which is no problem, since it reappears as soon as a new non empty topic is set again.
I actually believe this to be quite nice. But I see basically no difference to the typing notification code, where that behaviour would be even more awesome.

Actually now sometimes the typing notification bar also disappears. This makes Bug #61 even worse.

Can you guys explain that to me?