### PR TITLE
Fix scroll momentum

### DIFF
--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -23,6 +23,7 @@ Rectangle {
         model: messageModel
         delegate: messageDelegate
         flickableDirection: Flickable.VerticalFlick
+        flickDeceleration: 9001
         boundsBehavior: Flickable.StopAtBounds
         pixelAligned: true
         property bool wasAtEndY: true


### PR DESCRIPTION
Sets a high flickDeceleration in the chatview.

I know this fix is pretty stupid. But it fixes the UX for me and I guess everyone else.
Stopping at a certain position in the chat with the mouse wheel is quite impossible right now.
QML might be designed for touchscreens as primary input devices. Quaternion isn’t. (If I’m wrong here, please let me know.)

The exact value could be tweaked, of course. A very high value will (I tested that) break the slider, as I predicted. This value is probably not perfect but gives me a much more satisfying behaviour.