### PR TITLE
Don‘t send everything the user enters, if it is probably unintended

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -217,6 +217,17 @@ void ChatRoomWidget::sendLine()
             {
                 text.remove(0, 3);
                 m_currentConnection->postMessage(m_currentRoom, "m.emote", text);
+            }
+            else if( text.startsWith("//") )
+            {
+                text.remove(0, 1);
+                m_currentConnection->postMessage(m_currentRoom, "m.text", text);
+            }
+            else if( text.startsWith("/") )
+            {
+                m_currentlyTyping->setText( "Unknown command. Use // to send this line literally" );
+                QTimer::singleShot(5000, this, SLOT(typingChanged()));
+                return;
             } else
                 m_currentConnection->postMessage(m_currentRoom, "m.text", text);
         }

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -225,8 +225,7 @@ void ChatRoomWidget::sendLine()
             }
             else if( text.startsWith("/") )
             {
-                m_currentlyTyping->setText( "Unknown command. Use // to send this line literally" );
-                QTimer::singleShot(5000, this, SLOT(typingChanged()));
+                emit showStatusMessage( "Unknown command. Use // to send this line literally", 5000);
                 return;
             } else
                 m_currentConnection->postMessage(m_currentRoom, "m.text", text);

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -191,6 +191,8 @@ void ChatRoomWidget::sendLine()
     if( !m_currentConnection )
         return;
     QString text = m_chatEdit->displayText();
+    if ( text.isEmpty() )
+        return;
 
     // Commands available without current room
     if( text.startsWith("/join") )

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -50,6 +50,7 @@ class ChatRoomWidget: public QWidget
 
     signals:
         void joinRoomNeedsInteraction();
+        void showStatusMessage(const QString& message, int timeout);
 
     public slots:
         void setRoom(QuaternionRoom* room);

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -52,6 +52,7 @@ MainWindow::MainWindow()
     connect( chatRoomWidget, &ChatRoomWidget::joinRoomNeedsInteraction, this, &MainWindow::showJoinRoomDialog);
     connect( roomListDock, &RoomListDock::roomSelected, chatRoomWidget, &ChatRoomWidget::setRoom );
     connect( roomListDock, &RoomListDock::roomSelected, userListDock, &UserListDock::setRoom );
+    connect( chatRoomWidget, &ChatRoomWidget::showStatusMessage, statusBar(), &QStatusBar::showMessage );
     systemTray = new SystemTray(this);
     createMenu();
     loadSettings();


### PR DESCRIPTION
Don’t send unknown commands and empty messages.

The display of the warning to the user is slightly buggy.
(Meaning the message might disappear too fast, if it is displayed multiple times in 5 seconds.)
But this is probably only a temporary solution anyways, until we get local echo.

On the other hand I am not sure if we really want warnings like this permanently in the timeline.
We could give it a timeout in the timeline, which would probably be pretty neat. We could also do typing notifications with that.