### PR TITLE
Detect activity to not set readmarker too fast

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -115,6 +115,12 @@ ChatRoomWidget::~ChatRoomWidget()
 {
 }
 
+void ChatRoomWidget::lookAtRoom()
+{
+    if ( m_currentRoom )
+        m_currentRoom->lookAt();
+}
+
 void ChatRoomWidget::enableDebug()
 {
     QQmlContext* ctxt = m_quickView->rootContext();

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -47,6 +47,7 @@ class ChatRoomWidget: public QWidget
         void enableDebug();
         void triggerCompletion();
         void cancelCompletion();
+        void lookAtRoom();
 
     signals:
         void joinRoomNeedsInteraction();

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -37,7 +37,7 @@ class ActivityDetector : public QObject
             switch (ev->type())
             {
             case QEvent::KeyPress:
-            case QEvent::ApplicationActivate:
+            case QEvent::FocusIn:
             case QEvent::MouseMove:
             case QEvent::MouseButtonPress:
                 m_mainWindow->activity();

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -24,6 +24,32 @@
 
 #include "mainwindow.h"
 
+class ActivityDetector : public QObject
+{
+    public:
+        ActivityDetector(MainWindow* c): m_mainWindow(c)
+        {
+            c->setMouseTracking(true);
+        };
+    protected:
+        bool eventFilter(QObject* obj, QEvent* ev)
+        {
+            switch (ev->type())
+            {
+            case QEvent::KeyPress:
+            case QEvent::ApplicationActivate:
+            case QEvent::MouseMove:
+            case QEvent::MouseButtonPress:
+                m_mainWindow->activity();
+            default:;
+            }
+            return QObject::eventFilter(obj, ev);
+        }
+    private:
+        MainWindow* m_mainWindow;
+};
+
+
 int main( int argc, char* argv[] )
 {
     QApplication app(argc, argv);
@@ -54,6 +80,8 @@ int main( int argc, char* argv[] )
     MainWindow window;
     if( debugEnabled )
         window.enableDebug();
+    ActivityDetector ad(&window);
+    app.installEventFilter(&ad);
     window.show();
 
     return app.exec();

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -65,6 +65,11 @@ MainWindow::~MainWindow()
 {
 }
 
+void MainWindow::activity()
+{
+    chatRoomWidget->lookAtRoom();
+}
+
 void MainWindow::createMenu()
 {
     // Connection menu

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -43,6 +43,7 @@ class MainWindow: public QMainWindow
         virtual ~MainWindow();
 
         void enableDebug();
+        void activity();
 
         void setConnection(QuaternionConnection* newConnection);
 

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -38,6 +38,18 @@ QuaternionRoom::QuaternionRoom(QMatrixClient::Connection* connection, QString ro
 QuaternionRoom::~QuaternionRoom()
 { }
 
+void QuaternionRoom::lookAt()
+{
+    if ( !messageEvents().empty() && lastReadEvent(connection()->user()) != messageEvents().last()->id() )
+        markMessageAsRead( messageEvents().last() );
+    if( m_unreadMessages )
+    {
+        m_unreadMessages = false;
+        emit unreadMessagesChanged(this);
+        qDebug() << displayName() << "no unread messages";
+    }
+}
+
 void QuaternionRoom::setShown(bool shown)
 {
     if( shown == m_shown )
@@ -45,14 +57,6 @@ void QuaternionRoom::setShown(bool shown)
     m_shown = shown;
     if( m_shown )
     {
-        if ( !messageEvents().empty() && lastReadEvent(connection()->user()) != messageEvents().last()->id() )
-            markMessageAsRead( messageEvents().last() );
-        if( m_unreadMessages )
-        {
-            m_unreadMessages = false;
-            emit unreadMessagesChanged(this);
-            qDebug() << displayName() << "no unread messages";
-        }
         resetHighlightCount();
         resetNotificationCount();
     }
@@ -91,11 +95,7 @@ void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
             new_message = true;
     }
 
-    if( m_shown )
-    {
-        markMessageAsRead(messageEvents().back());
-    }
-    else if( !m_unreadMessages && new_message)
+    if( !m_unreadMessages && new_message)
     {
         m_unreadMessages = true;
         emit unreadMessagesChanged(this);

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -43,16 +43,16 @@ void QuaternionRoom::setShown(bool shown)
     if( shown == m_shown )
         return;
     m_shown = shown;
-    if( m_shown && m_unreadMessages )
-    {
-        if( !messageEvents().empty() )
-            markMessageAsRead( messageEvents().last() );
-        m_unreadMessages = false;
-        emit unreadMessagesChanged(this);
-        qDebug() << displayName() << "no unread messages";
-    }
     if( m_shown )
     {
+        if ( !messageEvents().empty() && lastReadEvent(connection()->user()) != messageEvents().last()->id() )
+            markMessageAsRead( messageEvents().last() );
+        if( m_unreadMessages )
+        {
+            m_unreadMessages = false;
+            emit unreadMessagesChanged(this);
+            qDebug() << displayName() << "no unread messages";
+        }
         resetHighlightCount();
         resetNotificationCount();
     }
@@ -83,14 +83,19 @@ void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
     Room::doAddNewMessageEvents(events);
 
     m_messages.reserve(m_messages.size() + events.size());
+    bool new_message = false;
     for (auto e: events)
+    {
         m_messages.push_back(makeMessage(e));
+        if ( e->type() == QMatrixClient::EventType::RoomMessage )
+            new_message = true;
+    }
 
     if( m_shown )
     {
         markMessageAsRead(messageEvents().back());
     }
-    else if( !m_unreadMessages )
+    else if( !m_unreadMessages && new_message)
     {
         m_unreadMessages = true;
         emit unreadMessagesChanged(this);
@@ -110,13 +115,21 @@ void QuaternionRoom::doAddHistoricalMessageEvents(const QMatrixClient::Events& e
 void QuaternionRoom::processEphemeralEvent(QMatrixClient::Event* event)
 {
     QMatrixClient::Room::processEphemeralEvent(event);
-    QString lastReadId = lastReadEvent(connection()->user());
-    if( m_unreadMessages &&
-            (messageEvents().isEmpty() || lastReadId == messageEvents().last()->id()) )
+    if ( m_unreadMessages && event->type() == QMatrixClient::EventType::Receipt )
     {
-        m_unreadMessages = false;
-        emit unreadMessagesChanged(this);
-        qDebug() << displayName() << "no unread messages";
+        QString lastReadId = lastReadEvent(connection()->user());
+        for (int i = messageEvents().size()-1; i >= 0; i--)
+        {
+            if ( lastReadId == messageEvents().at(i)->id() )
+            {
+                m_unreadMessages = false;
+                emit unreadMessagesChanged(this);
+                qDebug() << displayName() << "no unread messages";
+                break;
+            }
+            if ( messageEvents().at(i)->type() == QMatrixClient::EventType::RoomMessage )
+                break;
+        }
     }
 }
 

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -93,6 +93,8 @@ void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
         m_messages.push_back(makeMessage(e));
         if ( e->type() == QMatrixClient::EventType::RoomMessage )
             new_message = true;
+        if ( e->senderId() == connection()->userId() )
+            markMessageAsRead( e );
     }
 
     if( !m_unreadMessages && new_message)

--- a/client/quaternionroom.h
+++ b/client/quaternionroom.h
@@ -39,6 +39,7 @@ class QuaternionRoom: public QMatrixClient::Room
          * This is used to mark messages as read.
          */
         void setShown(bool shown);
+        void lookAt();
         bool isShown();
 
         void setCachedInput(const QString& input);


### PR DESCRIPTION
If you don’t like this, regard it as a POC.
The architecture of this changes should allow easy extension to set the read marker to the end of the currently shown timeline as opposed to the end of the complete timeline as it is now.

There are concerns in the Docs, that this kind of EventFilter slows the program down.
But I don’t see another solution. And it still feels snappy to me.^^

(Note: This extends my other PR regarding marking rooms unread.)