### PR TITLE
Followup on the recent merges

### DIFF
--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -26,11 +26,13 @@ Rectangle {
         flickDeceleration: 9001
         boundsBehavior: Flickable.StopAtBounds
         pixelAligned: true
+        // FIXME: atYEnd is glitchy on Qt 5.2.1
+        property bool nowAtYEnd: contentY - originY + height >= contentHeight
         property bool wasAtEndY: true
 
         function aboutToBeInserted() {
-            wasAtEndY = atYEnd;
-            console.log("aboutToBeInserted! atYEnd=" + atYEnd);
+            wasAtEndY = nowAtYEnd;
+            console.log("aboutToBeInserted! nowAtYEnd=" + nowAtYEnd);
         }
 
         function rowsInserted() {
@@ -199,9 +201,9 @@ Rectangle {
             text: sourceText
         }
     }
-    Rectangle{
+    Rectangle {
         id: scrollindicator;
-        opacity: chatView.atYEnd ? 0 : 0.5
+        opacity: chatView.nowAtYEnd ? 0 : 0.5
         color: defaultPalette.text
         height: 30;
         radius: height/2;
@@ -209,7 +211,7 @@ Rectangle {
         anchors.left: parent.left;
         anchors.bottom: parent.bottom;
         anchors.leftMargin: width/2;
-        anchors.bottomMargin: chatView.atYEnd ? -height : height/2;
+        anchors.bottomMargin: chatView.nowAtYEnd ? -height : height/2;
         Behavior on opacity {
             NumberAnimation { duration: 300 }
         }

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -120,16 +120,17 @@ void QuaternionRoom::processEphemeralEvent(QMatrixClient::Event* event)
     if ( m_unreadMessages && event->type() == QMatrixClient::EventType::Receipt )
     {
         QString lastReadId = lastReadEvent(connection()->user());
-        for (int i = messageEvents().size()-1; i >= 0; i--)
+        for (auto it = messageEvents().end(); it != messageEvents().begin(); )
         {
-            if ( lastReadId == messageEvents().at(i)->id() )
+            --it;
+            if ( lastReadId == (*it)->id() )
             {
                 m_unreadMessages = false;
                 emit unreadMessagesChanged(this);
                 qDebug() << displayName() << "no unread messages";
                 break;
             }
-            if ( messageEvents().at(i)->type() == QMatrixClient::EventType::RoomMessage )
+            if ( (*it)->type() == QMatrixClient::EventType::RoomMessage )
                 break;
         }
     }

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -88,14 +88,17 @@ void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
 
     m_messages.reserve(m_messages.size() + events.size());
     bool new_message = false;
+    QMatrixClient::Event* lastOwnMessage = nullptr;
     for (auto e: events)
     {
         m_messages.push_back(makeMessage(e));
         if ( e->type() == QMatrixClient::EventType::RoomMessage )
             new_message = true;
         if ( e->senderId() == connection()->userId() )
-            markMessageAsRead( e );
+            lastOwnMessage = e;
     }
+    if (lastOwnMessage)
+        markMessageAsRead( lastOwnMessage );
 
     if( !m_unreadMessages && new_message)
     {
@@ -120,6 +123,7 @@ void QuaternionRoom::processEphemeralEvent(QMatrixClient::Event* event)
     if ( m_unreadMessages && event->type() == QMatrixClient::EventType::Receipt )
     {
         QString lastReadId = lastReadEvent(connection()->user());
+        // Older Qt doesn't provide QVector::rbegin()/rend()
         for (auto it = messageEvents().end(); it != messageEvents().begin(); )
         {
             --it;


### PR DESCRIPTION
1. I used iterators in that code in `QuaternionRoom`. Since there's no easy way to deal with reverse iterators in older Qt, I used ordinary ones; since I formally can't decrement before begin(), I used an easy workaround, decrementing the iterator the first thing in the loop body instead of `for` statement.
2. It turned out that ListView.atYEnd in older Qts (at least 5.2.1) ceases to update after one true/false/true turnaround. So I reimplemented the property - the home-grown one works flawlessly (although, probably, it's a little harder for the CPU).