### PR TITLE
Fix scrollToBottom

### DIFF
--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -14,6 +14,7 @@ Rectangle {
 
     Timer{
         id: scrollTimer
+        interval: 0
         onTriggered: reallyScrollToBottom()
     }
 

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -14,7 +14,6 @@ Rectangle {
 
     Timer{
         id: scrollTimer
-        interval: 1;
         onTriggered: reallyScrollToBottom()
     }
 


### PR DESCRIPTION
1. rename wasAtEndY to stickToBottom because seriously AtEndY vs.
AtYEnd was driving me crazy.

2. Don’t use aboutToBeInserted this is unreliable. Infact this event
will sometimes be triggerted in an inconvenient situation of the
population and unstick the scroll erroneously. Instead we track all the
time if we want to stickToBottom. The default is yes. And it only
changes when the user scrolls manually (onMovementStarted/onMovementEnded)
FIXME: This state should be tracked per room and perhaps depend on
the readmarker

3. Use a Timer Component to trigger the scrollingdown whenever
something changes. We need to give the controlflow away and scroll
after QML has updated and loaded the view. This has to be iterated,
because the scroll may trigger another update and loading …

This fixes #61.