### PR TITLE
More fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,15 +18,13 @@ init:
 
 before_build:
   - git submodule update --init --recursive
-  - cmake -G "NMake Makefiles JOM" -H. -Bbuild -DCMAKE_CXX_FLAGS="/EHsc /W3" -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX="%DEPLOY_DIR%" -DCMAKE_INSTALL_BINDIR="."
+  - cmake -G "NMake Makefiles JOM" -H. -Bbuild -DCMAKE_CXX_FLAGS="/EHsc /W3" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="%DEPLOY_DIR%" -DCMAKE_INSTALL_BINDIR="."
 
 build_script:
   - cmake --build build
 
 after_build:
   - cmake --build build --target install
-  - windeployqt --dir "%DEPLOY_DIR%" --release --no-system-d3d-compiler --no-opengl --no-multimedia --no-multimediaquick --no-declarative --no-test --qmldir "%QTDIR%\qml" "%DEPLOY_DIR%\quaternion.exe"
-
   - 7z a quaternion.zip "%DEPLOY_DIR%\"
 
 # Uncomment this to connect to the AppVeyor build worker

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ init:
 
 before_build:
   - git submodule update --init --recursive
-  - cmake -G "NMake Makefiles JOM" -H. -Bbuild -DCMAKE_CXX_FLAGS="/EHsc /W3" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="%DEPLOY_DIR%" -DCMAKE_INSTALL_BINDIR="."
+  - cmake -G "NMake Makefiles JOM" -H. -Bbuild -DCMAKE_CXX_FLAGS="/EHsc /W3" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="%DEPLOY_DIR%"
 
 build_script:
   - cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11) # Maybe works with an even older CMake
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
 
-project(quaternion)
-enable_language(CXX)
+project(quaternion CXX)
 
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
@@ -16,7 +15,6 @@ if(UNIX AND NOT APPLE)
     set(LINUX 1)
 endif(UNIX AND NOT APPLE)
 
-
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Debug' as none was specified")
@@ -26,21 +24,36 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "MinSizeRel" "RelWithDebInfo")
 endif()
 
+# Setup command line parameters for the compiler and linker
+CHECK_CXX_COMPILER_FLAG("-Wall" WALL_FLAG_SUPPORTED)
+if ( WALL_FLAG_SUPPORTED )
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+endif ( WALL_FLAG_SUPPORTED )
+
+if ( CMAKE_VERSION VERSION_LESS "3.1" )
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" STD_FLAG_SUPPORTED)
+    if ( STD_FLAG_SUPPORTED )
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif ( STD_FLAG_SUPPORTED )
+else ( CMAKE_VERSION VERSION_LESS "3.1" )
+    set(CMAKE_CXX_STANDARD 11)
+endif ( CMAKE_VERSION VERSION_LESS "3.1" )
+
 # Find the libraries
-find_package(Qt5Widgets 5.2.1 REQUIRED)
-find_package(Qt5Network 5.2.1 REQUIRED)
-find_package(Qt5Quick 5.2.1 REQUIRED)
-find_package(Qt5Qml 5.2.1 REQUIRED)
-find_package(Qt5Gui 5.2.1 REQUIRED)
+find_package(Qt5 5.2.1 REQUIRED Widgets Network Quick Qml Gui)
+get_filename_component(Qt5_Prefix "${Qt5_DIR}/../../../.." ABSOLUTE)
 
 message( STATUS )
-message( STATUS "================================================================================" )
-message( STATUS "                          Quaternion Build Information                          " )
-message( STATUS "================================================================================" )
-message( STATUS "Building with: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}" )
-message( STATUS "Install Prefix: ${CMAKE_INSTALL_PREFIX}" )
-message( STATUS "Path to Qt Core: ${Qt5Core_DIR}" )
-message( STATUS "================================================================================" )
+message( STATUS "=============================================================================" )
+message( STATUS "                          Quaternion Build Information" )
+message( STATUS "=============================================================================" )
+if (CMAKE_BUILD_TYPE)
+    message( STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+endif(CMAKE_BUILD_TYPE)
+message( STATUS "Using compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}" )
+message( STATUS "Using Qt ${Qt5_VERSION} at: ${Qt5_Prefix}" )
+message( STATUS "Quaternion install prefix: ${CMAKE_INSTALL_PREFIX}" )
+message( STATUS "=============================================================================" )
 message( STATUS )
 
 add_subdirectory(lib)
@@ -75,25 +88,9 @@ QT5_ADD_RESOURCES(quaternion_QRC_SRC ${quaternion_QRC})
 # TODO: MacOS builders, should MACOSX_BUNDLE be specified here as well?
 add_executable(quaternion WIN32 ${quaternion_SRCS} ${quaternion_QRC_SRC})
 
-# Setup command line parameters for the compiler and linker
-CHECK_CXX_COMPILER_FLAG("-Wall" WALL_FLAG_SUPPORTED)
-if ( WALL_FLAG_SUPPORTED )
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-endif ( WALL_FLAG_SUPPORTED )
-
-if ( CMAKE_VERSION VERSION_LESS "3.1" )
-    CHECK_CXX_COMPILER_FLAG("-std=c++11" STD_FLAG_SUPPORTED)
-    if ( STD_FLAG_SUPPORTED )
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif ( STD_FLAG_SUPPORTED )
-else ( CMAKE_VERSION VERSION_LESS "3.1" )
-    target_compile_features(quaternion PRIVATE cxx_range_for)
-    target_compile_features(quaternion PRIVATE cxx_override)
-    target_compile_features(quaternion PRIVATE cxx_auto_type)
-    target_compile_features(quaternion PRIVATE cxx_nullptr)
-endif ( CMAKE_VERSION VERSION_LESS "3.1" )
-
 target_link_libraries(quaternion qmatrixclient Qt5::Widgets Qt5::Quick Qt5::Qml Qt5::Gui Qt5::Network)
+
+# Installation
 
 install(TARGETS quaternion
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -106,3 +103,19 @@ if(LINUX)
                       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons
                       )
 endif(LINUX)
+
+if(WIN32)
+    install(CODE "
+        if (CMAKE_INSTALL_CONFIG_NAME STREQUAL \"Debug\")
+            set(WDQ_FLAG debug)
+        else()
+            set(WDQ_FLAG release)
+        endif()
+        execute_process(
+            COMMAND bin/windeployqt -\${WDQ_FLAG} --no-system-d3d-compiler --no-opengl
+                --no-multimedia --no-multimediaquick --no-declarative --no-test \
+                --qmldir qml \"\${CMAKE_INSTALL_PREFIX}/\${CMAKE_INSTALL_BINDIR}\"
+            WORKING_DIRECTORY \"\${qt5_libdir}/..\"
+        )
+    ")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if(WIN32)
             COMMAND bin/windeployqt -\${WDQ_FLAG} --no-system-d3d-compiler --no-opengl
                 --no-multimedia --no-multimediaquick --no-declarative --no-test \
                 --qmldir qml \"\${CMAKE_INSTALL_PREFIX}/\${CMAKE_INSTALL_BINDIR}\"
-            WORKING_DIRECTORY \"\${qt5_libdir}/..\"
+            WORKING_DIRECTORY \"\${Qt5_Prefix}/..\"
         )
     ")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,20 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
 
 project(quaternion CXX)
 
+if(UNIX AND NOT APPLE)
+    set(LINUX 1)
+endif(UNIX AND NOT APPLE)
+
 include(CheckCXXCompilerFlag)
-include(GNUInstallDirs)
-include(cmake/ECMInstallIcons.cmake)
+if (NOT WIN32)
+    include(GNUInstallDirs)
+    include(cmake/ECMInstallIcons.cmake)
+endif(NOT WIN32)
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
-
-if(UNIX AND NOT APPLE)
-    set(LINUX 1)
-endif(UNIX AND NOT APPLE)
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -51,7 +53,7 @@ if (CMAKE_BUILD_TYPE)
     message( STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 endif(CMAKE_BUILD_TYPE)
 message( STATUS "Using compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}" )
-message( STATUS "Using Qt ${Qt5_VERSION} at: ${Qt5_Prefix}" )
+message( STATUS "Using Qt ${Qt5_VERSION} at ${Qt5_Prefix}" )
 message( STATUS "Quaternion install prefix: ${CMAKE_INSTALL_PREFIX}" )
 message( STATUS "=============================================================================" )
 message( STATUS )
@@ -92,6 +94,10 @@ target_link_libraries(quaternion qmatrixclient Qt5::Widgets Qt5::Quick Qt5::Qml 
 
 # Installation
 
+if (NOT CMAKE_INSTALL_BINDIR)
+    set(CMAKE_INSTALL_BINDIR ".")
+endif()
+
 install(TARGETS quaternion
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if(LINUX)
@@ -105,17 +111,31 @@ if(LINUX)
 endif(LINUX)
 
 if(WIN32)
-    install(CODE "
-        if (CMAKE_INSTALL_CONFIG_NAME STREQUAL \"Debug\")
-            set(WDQ_FLAG debug)
-        else()
-            set(WDQ_FLAG release)
-        endif()
-        execute_process(
-            COMMAND bin/windeployqt -\${WDQ_FLAG} --no-system-d3d-compiler --no-opengl
-                --no-multimedia --no-multimediaquick --no-declarative --no-test \
-                --qmldir qml \"\${CMAKE_INSTALL_PREFIX}/\${CMAKE_INSTALL_BINDIR}\"
-            WORKING_DIRECTORY \"\${Qt5_Prefix}/..\"
-        )
-    ")
-endif()
+    if (${Qt5_VERSION} VERSION_LESS "5.3")
+        install(CODE "
+            message(\"Deploying on Windows is only supported with Qt 5.3 or higher\")
+            message(\"Bare executable has been copied to the target folder\")
+        ")
+    else()
+        get_filename_component(Qt5_WinBaseDir "${Qt5_DIR}/../../.." ABSOLUTE)
+        install(CODE "
+            if (CMAKE_INSTALL_CONFIG_NAME STREQUAL \"Debug\")
+                set(WDQ_FLAG debug)
+            else()
+                set(WDQ_FLAG release)
+            endif()
+            execute_process(
+                COMMAND bin/windeployqt --\${WDQ_FLAG} --no-system-d3d-compiler --no-opengl
+                    --no-multimedia --no-multimediaquick --no-declarative --no-test \
+                    --qmldir qml \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
+                WORKING_DIRECTORY \"${Qt5_WinBaseDir}\"
+                RESULT_VARIABLE WDQ_RETVAL
+            )
+            if (WDQ_RETVAL)
+                message( \"windeployqt returned \${WDQ_RETVAL} - check messages above\")
+            else()
+                message( STATUS \"Quaternion and its dependencies have been deployed to \${CMAKE_INSTALL_PREFIX}.\")
+            endif()
+        ")
+    endif()
+endif(WIN32)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ You can also file outright bugs at [the project's issue tracker](https://github.
 - a Linux, MacOS or Windows system (desktop versions tried; mobile Linux/Windows might work too)
   - For Ubuntu flavours - Trusty Tar or later (or a derivative) is good enough; older ones will need PPAs at least for a newer Qt
 - a Git client (to check out this repo)
-- CMake (from your package management system or https://cmake.org/download/)
+- CMake (from your package management system or [the official website](https://cmake.org/download/))
 - Qt 5 (either Open Source or Commercial), version 5.2.1 or higher as of this writing (check the CMakeLists.txt for most up-to-date information). Qt 5.3 or higher recommended on Windows.
-- a C++ toolchain supported by Qt 5.2.1 or later (see a link for your platform at http://doc.qt.io/qt-5/gettingstarted.html#platform-requirements)
+- a C++ toolchain supported by Qt 5.2.1 or later (see a link for your platform at [the Qt's platform requirements page](http://doc.qt.io/qt-5/gettingstarted.html#platform-requirements))
   - GCC 4.8, Clang 3.5.0, Visual C++ 2013 are the oldest officially supported by Quaternion as of this writing
 
 ## Installing pre-requisites
@@ -30,7 +30,7 @@ sudo apt-get install git cmake qtdeclarative5-dev qtdeclarative5-qtquick2-plugin
 
 ### Windows
 1. Install a Git client and CMake. The commands here imply that git and cmake are in your PATH - otherwise you have to prepend them with your actual paths.
-1. Install Qt5, using their official installer. If for some reason you need to use Qt 5.2.1, select its Add-ons component in the installer as well; for later versions, no extras are needed. If you don't have a toolchain and/or IDE, you can easily get one by selecting Qt Creator and at least one toolchain under Qt Creator.
+1. Install Qt5, using their official installer. If for some reason you need to use Qt 5.2.1, select its Add-ons component in the installer as well; for later versions, no extras are needed. If you don't have a toolchain and/or IDE, you can easily get one by selecting Qt Creator and at least one toolchain under Qt Creator. At least Qt 5.3 is recommended on Windows; `windeployqt` in Qt 5.2.1 is not functional enough to provide a standalone installation for Quaternion; but you can still compile and run it from your build directory.  
 1. Make sure CMake knows about Qt and the toolchain - the easiest way is to run a qtenv2.bat script that can be found in `C:\Qt\<Qt version>\<toolchain>\bin` (assuming you installed Qt to `C:\Qt`). The only thing it does is adding necessary paths to PATH - you might not want to run it on system startup but it's very handy to setup environment before building. Setting CMAKE_PREFIX_PATH, the same way as for OS X (see above), also helps.
 
 There are no official MinGW-based 64-bit packages for Qt. If you're determined to build 64-bit Quaternion, either use a Visual Studio toolchain or build Qt5 yourself as described in Qt documentation.

--- a/README.md
+++ b/README.md
@@ -4,51 +4,73 @@ Quaternion is a cross-platform desktop IM client for the [Matrix](https://matrix
 ## Version 0.0.1 out now!
 The release (including binaries for Windows) can be found [here](https://github.com/Fxrh/Quaternion/releases/tag/v0.0.1).
 
+## Contacts
+Most of talking around Quaternion happens in our Matrix room: [#quaternion:matrix.org](https://matrix.to/#/#quaternion:matrix.org).
+
+You can also file outright bugs at [the project's issue tracker](https://github.com/Fxrh/Quaternion/issues).
+
 ## Pre-requisites
 - a Linux, MacOS or Windows system (desktop versions tried; mobile Linux/Windows might work too)
+  - For Ubuntu flavours - Trusty Tar or later (or a derivative) is good enough; older ones will need PPAs at least for a newer Qt
 - a Git client (to check out this repo)
-- a C++ toolchain that can deal with C++11 and Qt5 (see a link for your platform at http://doc.qt.io/qt-5/gettingstarted.html#platform-requirements)
 - CMake (from your package management system or https://cmake.org/download/)
-- Qt 5 (either Open Source or Commercial), version 5.2.1 or higher as of this writing (check the CMakeLists.txt for details)
+- Qt 5 (either Open Source or Commercial), version 5.2.1 or higher as of this writing (check the CMakeLists.txt for most up-to-date information). Qt 5.3 or higher recommended on Windows.
+- a C++ toolchain supported by Qt 5.2.1 or later (see a link for your platform at http://doc.qt.io/qt-5/gettingstarted.html#platform-requirements)
+  - GCC 4.8, Clang 3.5.0, Visual C++ 2013 are the oldest officially supported by Quaternion as of this writing
+
+## Installing pre-requisites
+### Linux
+Just install things from "Pre-requisites" using your preferred package manager. If your Qt package base is fine-grained you might want to take a look at CMakeLists.txt to figure out which specific libraries Quaternion uses (or blindly run cmake and look at error messages). Note also that you'll need several Qt Quick plugins for Quaternion to work (without them, it will compile and run but won't show the messages timeline). In case of Trusty Tar the following line will get you everything necessary to build and run Quaternion (thanks to @onlnr:matrix.org):
+```
+sudo apt-get install git cmake qtdeclarative5-dev qtdeclarative5-qtquick2-plugin qtdeclarative5-controls-plugin
+```
+
+### OS X
+`brew install qt5` should get you Qt5. You may need to tell CMake about the path to Qt by passing `-DCMAKE_PREFIX_PATH=<where-Qt-installed>`
+
+### Windows
+1. Install a Git client and CMake. The commands here imply that git and cmake are in your PATH - otherwise you have to prepend them with your actual paths.
+1. Install Qt5, using their official installer. If for some reason you need to use Qt 5.2.1, select its Add-ons component in the installer as well; for later versions, no extras are needed. If you don't have a toolchain and/or IDE, you can easily get one by selecting Qt Creator and at least one toolchain under Qt Creator.
+1. Make sure CMake knows about Qt and the toolchain - the easiest way is to run a qtenv2.bat script that can be found in `C:\Qt\<Qt version>\<toolchain>\bin` (assuming you installed Qt to `C:\Qt`). The only thing it does is adding necessary paths to PATH - you might not want to run it on system startup but it's very handy to setup environment before building. Setting CMAKE_PREFIX_PATH, the same way as for OS X (see above), also helps.
+
+There are no official MinGW-based 64-bit packages for Qt. If you're determined to build 64-bit Quaternion, either use a Visual Studio toolchain or build Qt5 yourself as described in Qt documentation.
 
 ## Source code
-Quaternion uses libqmatrixclient that resides in another repo but is not yet shipped as a separate library - it is fetched as a git submodule. To get all necessary sources, you can either supply `--recursive` to your `git clone` for Quaternion sources or do the following in the root directory of already cloned Quaternion sources (NOT in lib subdirectory):
+Quaternion uses libqmatrixclient that is developed in a separate GitHub repo and is fetched as a git submodule. To get all necessary sources:
+- if you haven't cloned the Quaternion sources, do it with `--recursive`
+- if you already have cloned Quaternion, do the following in the top-level directory (NOT in lib subdirectory):
 ```
 git submodule init
 git submodule update
 ```
 
-## Installing pre-requisites
-### Linux
-Just install things from "Pre-requisites" using your preferred package manager. If your Qt package base is fine-grained you might want to take a look at CMakeLists.txt to figure out which specific libraries Quaternion uses. You may also try to blindly run cmake and look at error messages.
-
-### OS X
-`brew install qt5` should get you Qt5. You may need to tell CMake about the path to Qt by passing -DCMAKE_PREFIX_PATH=<where-Qt-installed>
-
-### Windows
-1. Install a Git client and CMake. Make sure they are in your PATH.
-1. Install Qt5, using their official installer. No Qt extras are needed; but if you don't have a toolchain and/or IDE, include Qt Creator and at least one toolchain under Qt Creator.
-1. Make sure CMake knows about the toolchain - the easiest thing is to have it in your PATH as well.
-
-Unfortunately there are no official MinGW-based 64-bit packages for Qt. If you're determined to build 64-bit Quaternion, either use a Visual Studio toolchain or build Qt5 yourself as described in Qt documentation.
-
-### Building
-From the root directory of the project sources:
+## Building
+In the root directory of the project sources:
 ```
-mkdir build
-cd build
-cmake ../ # Pass -DCMAKE_PREFIX_PATH here if needed
-cmake --build build
+mkdir build_dir
+cd build_dir
+cmake .. # Pass -DCMAKE_PREFIX_PATH and -DCMAKE_INSTALL_PREFIX here if needed
+cmake --build . --target all
 ```
-This will get you an executable in the build directory inside your project sources.
+This will get you an executable in `build_dir` inside your project sources. `CMAKE_INSTALL_PREFIX` variable of CMake controls where Quaternion will be installed - pass it to `cmake ..` above if you wish to alter the default (see the output from `cmake ..` to find out the configured values).
 
 ## Running
-Just start the executable in your most preferred way. This implies at the moment that respective Qt5 libraries are in your PATH or next to the executable.
+Linux, MacOS: Just start the executable in your most preferred way. Windows: the same but before that make sure that Qt5 dlls and their dependencies are either in your PATH (see the note about `qtenv2.bat` in "Pre-requisites" above) or next to the executable (see "Installation on Windows" below).
 
-### Installation
-There's no automated way to install it at the moment; `sudo make install` should work on Linux, though.
+## Installation
+In the root directory of the project sources: `cmake --build build_dir --target install`.
 
-On Windows, you might want to use [the Windows Deployment Tool](http://doc.qt.io/qt-5/windows-deployment.html#the-windows-deployment-tool) that comes with Qt to find all dependencies and put them into the build directory. Though it misses on a library or two it helps a lot. To double-check that you're good to go you can use [the Dependencies Walker tool aka depends.exe](http://www.dependencywalker.com/) - this is especially needed when you have a mixed 32/64-bit environment or have different versions of the same library scattered around (libssl is notorious to be dragged along by all kinds of software).
+On Linux, `make install` (with `sudo` if needed) will work equally well.
+
+### Installation on Windows
+Since we can't rely on package management on Windows, Qt libraries and the runtime are installed together with Quaternion. However, two libraries, namely ssleay32.dll and libeay32.dll from OpenSSL project, are not installed automatically because of export restrictions. Unless you already have them around (just in case: they are a part of Qt Creator installation), your best bet is to download these libraries yourself and either install them system-wide (which probably makes sense as soon as you keep them up-to-date) or put them next to quaternion.exe.
+
+In case of trouble with libraries on Windows, [the Dependencies Walker tool aka depends.exe](http://www.dependencywalker.com/) helps a lot in navigating the DLL hell - especially when you have a mixed 32/64-bit environment or have different versions of the same library scattered around (OpenSSL is notoriously often dragged along by all kinds of software; and you may have other copies of Qt around which you didn't even realise to exist - with CMake GUI, e.g.).
+
+## Packaging
+There's no official packaging at the moment. Some links to unofficial packages follow:
+Arch Linux: https://aur.archlinux.org/packages/quaternion/
+Windows: automatic builds are packaged upon every commit (CI) at https://ci.appveyor.com/project/Fxrh/quaternion (go to "Jobs", select the job for your architecture, then "Artifacts")
 
 ## Troubleshooting
 
@@ -71,6 +93,8 @@ CMake Error at CMakeLists.txt:30 (add_subdirectory):
   does not contain a CMakeLists.txt file.
 ```
 ...then you don't have libqmatrixclient sources - most likely because you didn't do the `git submodule init && git submodule update` dance.
+
+If Quaternion runs but you can't see any messages in the chat (though you can type them in) - you have a problem with Qt Quick. Most likely, you don't have Qt Quick libraries and/or plugins installed. On Linux, double check "Pre-requisites" above. On Windows and Mac, just open an issue (see "Contacts" section in the beginning of this README), because most likely not all necessary Qt parts got installed.
 
 ## Screenshot
 ![Screenshot](quaternion.png)

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -130,6 +130,9 @@ void ChatRoomWidget::enableDebug()
 
 void ChatRoomWidget::setRoom(QuaternionRoom* room)
 {
+    if (m_currentRoom == room)
+        return;
+
     if( m_currentRoom )
     {
         m_currentRoom->setCachedInput( m_chatEdit->displayText() );

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -34,12 +34,10 @@
 #include "lib/room.h"
 #include "lib/user.h"
 #include "lib/connection.h"
-#include "lib/logmessage.h"
 #include "lib/jobs/postmessagejob.h"
-#include "lib/events/event.h"
 #include "lib/events/typingevent.h"
-#include "models/messageeventmodel.h"
 #include "quaternionroom.h"
+#include "models/messageeventmodel.h"
 #include "imageprovider.h"
 
 class ChatEdit : public QLineEdit

--- a/client/imageprovider.cpp
+++ b/client/imageprovider.cpp
@@ -64,9 +64,6 @@ void ImageProvider::doRequest(QString id, QSize requestedSize, QPixmap* pixmap, 
 {
     QMutexLocker locker(&m_mutex);
 
-    int width = requestedSize.width() > 0 ? requestedSize.width() : 100;
-    int height = requestedSize.height() > 0 ? requestedSize.height() : 100;
-
     if( !m_connection )
     {
         qDebug() << "ImageProvider::requestPixmap: no connection!";
@@ -74,8 +71,8 @@ void ImageProvider::doRequest(QString id, QSize requestedSize, QPixmap* pixmap, 
         condition->wakeAll();
     }
 
-    QMatrixClient::MediaThumbnailJob* job = m_connection->getThumbnail(QUrl(id), width, height);
-    QObject::connect( job, &QMatrixClient::MediaThumbnailJob::success, this, &ImageProvider::gotImage );
+    auto job = m_connection->getThumbnail(QUrl(id), requestedSize.expandedTo({100,100}));
+    connect( job, &QMatrixClient::MediaThumbnailJob::success, this, &ImageProvider::gotImage );
     ImageProviderData data = { pixmap, condition, requestedSize };
     m_callmap.insert(job, data);
 }

--- a/client/imageprovider.cpp
+++ b/client/imageprovider.cpp
@@ -20,10 +20,6 @@
 #include "imageprovider.h"
 #include <jobs/mediathumbnailjob.h>
 
-#include <QtCore/QMutex>
-#include <QtCore/QMutexLocker>
-#include <QtCore/QWaitCondition>
-
 #include <QtCore/QDebug>
 
 ImageProvider::ImageProvider(QMatrixClient::Connection* connection)

--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -25,7 +25,6 @@
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QFormLayout>
 
-#include <QtCore/QDebug>
 #include <QtCore/QUrl>
 
 #include "quaternionconnection.h"

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -19,7 +19,6 @@
 
 #include <QtWidgets/QApplication>
 #include <QtCore/QCommandLineParser>
-#include <QtCore/QCommandLineOption>
 #include <QtCore/QDebug>
 
 #include "mainwindow.h"

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -139,7 +139,6 @@ void MainWindow::setConnection(QuaternionConnection* newConnection)
     if (connection)
     {
         chatRoomWidget->setConnection(nullptr);
-        userListDock->setConnection(nullptr);
         roomListDock->setConnection(nullptr);
         systemTray->setConnection(nullptr);
 
@@ -155,7 +154,6 @@ void MainWindow::setConnection(QuaternionConnection* newConnection)
     if (connection)
     {
         chatRoomWidget->setConnection(connection);
-        userListDock->setConnection(connection);
         roomListDock->setConnection(connection);
         systemTray->setConnection(connection);
 

--- a/client/message.cpp
+++ b/client/message.cpp
@@ -28,8 +28,7 @@
 Message::Message(QMatrixClient::Connection* connection,
                  QMatrixClient::Event* event,
                  QMatrixClient::Room* room)
-    : m_connection(connection)
-    , m_event(event)
+    : m_event(event)
     , m_isHighlight(false)
     , m_isStatusMessage(true)
 {
@@ -38,7 +37,7 @@ Message::Message(QMatrixClient::Connection* connection,
     {
         m_isStatusMessage = false;
         RoomMessageEvent* messageEvent = static_cast<RoomMessageEvent*>(event);
-        User* localUser = m_connection->user();
+        User* localUser = connection->user();
         // Only highlight messages from other users
         if (messageEvent->senderId() != localUser->id())
         {

--- a/client/message.h
+++ b/client/message.h
@@ -44,7 +44,6 @@ class Message
         bool isStatusMessage() const;
 
     private:
-        QMatrixClient::Connection* m_connection;
         QMatrixClient::Event* m_event;
         bool m_isHighlight;
         bool m_isStatusMessage;

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -19,16 +19,13 @@
 
 #include "messageeventmodel.h"
 
-#include <QtCore/QStringBuilder>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
 
 #include "../message.h"
 #include "../quaternionroom.h"
 #include "lib/connection.h"
-#include "lib/room.h"
 #include "lib/user.h"
-#include "lib/events/event.h"
 #include "lib/events/roommessageevent.h"
 #include "lib/events/roommemberevent.h"
 #include "lib/events/roomnameevent.h"

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -20,12 +20,15 @@
 #ifndef LOGMESSAGEMODEL_H
 #define LOGMESSAGEMODEL_H
 
-#include "../quaternionroom.h"
-
 #include <QtCore/QAbstractListModel>
 #include <QtCore/QModelIndex>
 
+namespace QMatrixClient
+{
+    class Connection;
+}
 class Message;
+class QuaternionRoom;
 
 class MessageEventModel: public QAbstractListModel
 {

--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -19,8 +19,6 @@
 
 #include "roomlistmodel.h"
 
-#include <QtGui/QBrush>
-#include <QtGui/QColor>
 #include <QtGui/QIcon>
 
 #include <QtCore/QDebug>

--- a/client/models/userlistmodel.cpp
+++ b/client/models/userlistmodel.cpp
@@ -60,19 +60,11 @@ class MemberNameSorter
 UserListModel::UserListModel(QObject* parent)
     : QAbstractListModel(parent)
 {
-    m_connection = nullptr;
     m_currentRoom = nullptr;
 }
 
 UserListModel::~UserListModel()
 {
-}
-
-void UserListModel::setConnection(QMatrixClient::Connection* connection)
-{
-    setRoom(nullptr);
-
-    m_connection = connection;
 }
 
 void UserListModel::setRoom(QMatrixClient::Room* room)

--- a/client/models/userlistmodel.cpp
+++ b/client/models/userlistmodel.cpp
@@ -77,6 +77,9 @@ void UserListModel::setConnection(QMatrixClient::Connection* connection)
 
 void UserListModel::setRoom(QMatrixClient::Room* room)
 {
+    if (m_currentRoom == room)
+        return;
+
     using namespace QMatrixClient;
     beginResetModel();
     if( m_currentRoom )

--- a/client/models/userlistmodel.h
+++ b/client/models/userlistmodel.h
@@ -36,8 +36,7 @@ class UserListModel: public QAbstractListModel
         UserListModel(QObject* parent = nullptr);
         virtual ~UserListModel();
 
-        void setConnection(QMatrixClient::Connection* connection);
-        void setRoom(QMatrixClient::Room* room);
+    void setRoom(QMatrixClient::Room* room);
 
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         int rowCount(const QModelIndex& parent=QModelIndex()) const override;
@@ -49,7 +48,6 @@ class UserListModel: public QAbstractListModel
         void avatarChanged(QMatrixClient::User* user);
 
     private:
-        QMatrixClient::Connection* m_connection;
         QMatrixClient::Room* m_currentRoom;
         QList<QMatrixClient::User*> m_users;
 };

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -20,7 +20,6 @@
 #include "roomlistdock.h"
 
 #include <QtCore/QSettings>
-#include <QtCore/QDebug>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QStyledItemDelegate>
 

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -93,13 +93,15 @@ RoomListDock::~RoomListDock()
 
 void RoomListDock::setConnection( QMatrixClient::Connection* connection )
 {
+    emit roomSelected(nullptr);
     this->connection = connection;
     model->setConnection(connection);
 }
 
 void RoomListDock::rowSelected(const QModelIndex& index)
 {
-    emit roomSelected( model->roomAt(index.row()) );
+    if (index.isValid())
+        emit roomSelected( model->roomAt(index.row()) );
 }
 
 void RoomListDock::showContextMenu(const QPoint& pos)

--- a/client/userlistdock.cpp
+++ b/client/userlistdock.cpp
@@ -45,11 +45,6 @@ UserListDock::~UserListDock()
 {
 }
 
-void UserListDock::setConnection(QMatrixClient::Connection* connection)
-{
-    m_model->setConnection(connection);
-}
-
 void UserListDock::setRoom(QMatrixClient::Room* room)
 {
     m_model->setRoom(room);

--- a/client/userlistdock.h
+++ b/client/userlistdock.h
@@ -38,8 +38,7 @@ class UserListDock: public QDockWidget
         UserListDock(QWidget* parent = nullptr);
         virtual ~UserListDock();
 
-        void setConnection( QMatrixClient::Connection* connection );
-        void setRoom( QMatrixClient::Room* room );
+    void setRoom( QMatrixClient::Room* room );
 
     private:
         QTableView* m_view;


### PR DESCRIPTION
Not having enough time for serious hacking, I took an opportunity to fix minor things here and there. Among highlights - `make install`, or rather, `cmake --build . --target install`, on Windows carry over the nevessary Qt libraries to the installation folder as well, so the whole build-install-run process becomes (almost) perfectly automated.
