### PR TITLE
Fix build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ From the root directory of the project sources:
 mkdir build
 cd build
 cmake ../ # Pass -DCMAKE_PREFIX_PATH here if needed
-cmake --build build
+cmake --build .
 ```
 This will get you an executable in the build directory inside your project sources.
 


### PR DESCRIPTION
The last part should be "cmake --build ." because we already
cd'd into the build directory

This has been irking me since I've built Quaternion the first time...