### PR TITLE
Don’t raise the mainwindow on highlight, just send an activateEvent

### DIFF
--- a/client/systemtray.cpp
+++ b/client/systemtray.cpp
@@ -55,6 +55,6 @@ void SystemTray::highlightCountChanged(QMatrixClient::Room* room)
     if( room->highlightCount() > 0 )
     {
         showMessage(tr("Highlight!"), tr("%1: %2 highlight(s)").arg(room->displayName()).arg(room->highlightCount()));
-        m_parent->raise();
+        m_parent->activateWindow();
     }
 }


### PR DESCRIPTION
This should fix #113. But this needs testing with different WMs, to see if it is the intended behaviour.

Works like intended with i3wm.
I’d like to here from xfce, kde and windows.
