### PR TITLE
Better read marker

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -70,6 +70,7 @@ bool ChatEdit::event(QEvent *event)
 ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     : QWidget(parent)
 {
+    qmlRegisterType<QuaternionRoom>();
     m_messageModel = new MessageEventModel(this);
     m_currentRoom = nullptr;
     m_currentConnection = nullptr;

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -118,8 +118,7 @@ ChatRoomWidget::~ChatRoomWidget()
 
 void ChatRoomWidget::lookAtRoom()
 {
-    if ( m_currentRoom )
-        m_currentRoom->lookAt();
+    m_messageModel->markShownAsRead();
 }
 
 void ChatRoomWidget::enableDebug()
@@ -162,7 +161,6 @@ void ChatRoomWidget::setConnection(QMatrixClient::Connection* connection)
     setRoom(nullptr);
     m_currentConnection = connection;
     m_imageProvider->setConnection(connection);
-    m_messageModel->setConnection(connection);
 }
 
 void ChatRoomWidget::typingChanged()

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -64,8 +64,8 @@ QHash<int, QByteArray> MessageEventModel::roleNames() const
 
 MessageEventModel::MessageEventModel(QObject* parent)
     : QAbstractListModel(parent)
-    , m_connection(nullptr)
     , m_currentRoom(nullptr)
+    , lastShownIndex(-1)
 { }
 
 MessageEventModel::~MessageEventModel()
@@ -74,41 +74,34 @@ MessageEventModel::~MessageEventModel()
 
 void MessageEventModel::changeRoom(QuaternionRoom* room)
 {
+    if (room == m_currentRoom)
+        return;
+
     beginResetModel();
     if( m_currentRoom )
         m_currentRoom->disconnect( this );
 
     m_currentRoom = room;
+    lastShownIndex = -1;
     if( room )
     {
         using namespace QMatrixClient;
-        connect(m_currentRoom, &QuaternionRoom::aboutToAddNewMessages,
+        connect(m_currentRoom, &Room::aboutToAddNewMessages,
                 [=](const Events& events)
                 {
                     beginInsertRows(QModelIndex(),
                                     rowCount(), rowCount() + events.size() - 1);
                 });
-        connect(m_currentRoom, &QuaternionRoom::aboutToAddHistoricalMessages,
+        connect(m_currentRoom, &Room::aboutToAddHistoricalMessages,
                 [=](const Events& events)
                 {
                     beginInsertRows(QModelIndex(), 0, events.size() - 1);
                 });
-        connect(m_currentRoom, &QuaternionRoom::addedMessages,
+        connect(m_currentRoom, &Room::addedMessages,
                 this, &MessageEventModel::endInsertRows);
-        connect(m_currentRoom, &QuaternionRoom::lastReadEventChanged,
-                [=](const User* u) {
-                    if (u == m_connection->user())
-                        emit lastReadIdChanged();
-                });
-        emit lastReadIdChanged();
         qDebug() << "connected" << room;
     }
     endResetModel();
-}
-
-void MessageEventModel::setConnection(QMatrixClient::Connection* connection)
-{
-    m_connection = connection;
 }
 
 int MessageEventModel::rowCount(const QModelIndex& parent) const
@@ -121,7 +114,7 @@ int MessageEventModel::rowCount(const QModelIndex& parent) const
 QVariant MessageEventModel::data(const QModelIndex& index, int role) const
 {
     using namespace QMatrixClient;
-    if( !m_connection || !m_currentRoom ||
+    if( !m_currentRoom ||
             index.row() < 0 || index.row() >= m_currentRoom->messages().count())
         return QVariant();
 
@@ -135,8 +128,7 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
         if( event->type() == EventType::RoomMessage )
         {
             RoomMessageEvent* e = static_cast<RoomMessageEvent*>(event);
-            User* user = m_connection->user(e->userId());
-            return QString("%1 (%2): %3").arg(user->name()).arg(user->id()).arg(e->body());
+            return QString("%1: %2").arg(senderName, e->body());
         }
         if( event->type() == EventType::RoomMember )
         {
@@ -335,10 +327,11 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
     return QVariant();
 }
 
-QString MessageEventModel::lastReadId() const
+void MessageEventModel::markShownAsRead()
 {
-    if (m_currentRoom)
-        return m_currentRoom->lastReadEvent(m_connection->user());
-
-    return {};
+    if (m_currentRoom && lastShownIndex > -1)
+    {
+        auto lastShownMessage = m_currentRoom->messages().at(lastShownIndex);
+        m_currentRoom->markMessagesAsRead(lastShownMessage->messageEvent()->id());
+    }
 }

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -19,6 +19,7 @@
 
 #include "messageeventmodel.h"
 
+#include <QtCore/QTimerEvent>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
 
@@ -66,8 +67,7 @@ MessageEventModel::MessageEventModel(QObject* parent)
 { }
 
 MessageEventModel::~MessageEventModel()
-{
-}
+{ }
 
 void MessageEventModel::changeRoom(QuaternionRoom* room)
 {
@@ -80,6 +80,10 @@ void MessageEventModel::changeRoom(QuaternionRoom* room)
 
     m_currentRoom = room;
     lastShownIndex = -1;
+    for (int t: eventsToShownTimers)
+        killTimer(t);
+    eventsToShownTimers.clear();
+    shownTimersToEvents.clear();
     if( room )
     {
         using namespace QMatrixClient;
@@ -322,6 +326,73 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
     }
 
     return QVariant();
+}
+
+void MessageEventModel::onEventShownChanged(int evtIndex, QString evtId,
+                                            bool shown)
+{
+    if (!m_currentRoom)
+        return;
+
+    Q_ASSERT(evtId ==
+             m_currentRoom->messages().at(evtIndex)->messageEvent()->id());
+    // We track last shown events (and can update the read marker) only when
+    // the read marker is on-screen. Tracking is off when lastShownIndex is -1,
+    // and on otherwise.
+    if (m_currentRoom->readMarkerEventId() == evtId)
+    {
+        if (shown)
+        {
+            qDebug() << "Read marker is on-screen";
+            promoteLastShownEvent(evtIndex);
+        }
+        else
+        {
+            qDebug() << "Read marker is off-screen, last shown event:"
+                     << lastShownIndex << "-> -1";
+            lastShownIndex = -1;
+        }
+    }
+    if (shown && lastShownIndex != -1 && lastShownIndex < evtIndex)
+    {
+        // This message hasn't been shown before. If tracking
+        // last shown event is on (see above), wait for some time and if
+        // the message is still on the screen and the last shown index is
+        // behind it, advance it to the event.
+        eventsToShownTimers.insert(evtIndex,
+            shownTimersToEvents.insert(startTimer(1000), evtIndex).key());
+        qDebug() << "Scheduled last shown event update from"
+                 << lastShownIndex << "to" << evtIndex;
+    }
+    if (!shown && eventsToShownTimers.contains(evtIndex))
+    {
+        // The event's got scrolled off too soon? Not gonna be last shown.
+        const auto timerId = eventsToShownTimers.take(evtIndex);
+        shownTimersToEvents.remove(timerId);
+        killTimer(timerId);
+    }
+}
+
+void MessageEventModel::timerEvent(QTimerEvent* qte)
+{
+    if (shownTimersToEvents.contains(qte->timerId()))
+    {
+        const auto eventId = shownTimersToEvents.take(qte->timerId());
+        killTimer(qte->timerId());
+        eventsToShownTimers.remove(eventId);
+        promoteLastShownEvent(eventId);
+        return;
+    }
+    QAbstractListModel::timerEvent(qte);
+}
+
+void MessageEventModel::promoteLastShownEvent(int evtIndex)
+{
+    if (lastShownIndex < evtIndex)
+    {
+        qDebug() << "Last shown event:" << lastShownIndex << "->" << evtIndex;
+        lastShownIndex = evtIndex;
+    }
 }
 
 void MessageEventModel::markShownAsRead()

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -33,7 +33,6 @@ class MessageEventModel: public QAbstractListModel
 {
         Q_OBJECT
         Q_PROPERTY(QuaternionRoom* room MEMBER m_currentRoom CONSTANT)
-        Q_PROPERTY(int lastShownIndex MEMBER lastShownIndex NOTIFY lastShownIndexChanged)
     public:
         MessageEventModel(QObject* parent = nullptr);
         virtual ~MessageEventModel();
@@ -44,13 +43,18 @@ class MessageEventModel: public QAbstractListModel
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
 
-    signals:
-        void lastShownIndexChanged(int newValue);
-
     public slots:
+        void onEventShownChanged(int evtIndex, QString evtId, bool shown);
         void markShownAsRead();
+
+    protected:
+        void timerEvent(QTimerEvent* event) override;
 
     private:
         QuaternionRoom* m_currentRoom;
         int lastShownIndex;
+        QHash<int, int> eventsToShownTimers;
+        QHash<int, int> shownTimersToEvents;
+
+        void promoteLastShownEvent(int evtIndex);
 };

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -30,28 +30,27 @@ class Message;
 class MessageEventModel: public QAbstractListModel
 {
         Q_OBJECT
-        Q_PROPERTY(QString lastReadId READ lastReadId NOTIFY lastReadIdChanged STORED false)
+        Q_PROPERTY(QuaternionRoom* room MEMBER m_currentRoom CONSTANT)
+        Q_PROPERTY(int lastShownIndex MEMBER lastShownIndex NOTIFY lastShownIndexChanged)
     public:
         MessageEventModel(QObject* parent = nullptr);
         virtual ~MessageEventModel();
 
-        void setConnection(QMatrixClient::Connection* connection);
         void changeRoom(QuaternionRoom* room);
 
-        //override QModelIndex index(int row, int column, const QModelIndex& parent=QModelIndex()) const;
-        //override QModelIndex parent(const QModelIndex& index) const;
         int rowCount(const QModelIndex& parent = QModelIndex()) const override;
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
 
-        QString lastReadId() const;
-
     signals:
-        void lastReadIdChanged();
+        void lastShownIndexChanged(int newValue);
+
+    public slots:
+        void markShownAsRead();
 
     private:
-        QMatrixClient::Connection* m_connection;
         QuaternionRoom* m_currentRoom;
+        int lastShownIndex;
 };
 
 #endif // LOGMESSAGEMODEL_H

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -138,49 +138,8 @@ Rectangle {
                 y + message.height - 1 > chatView.contentY &&
                 y + message.height - 1 < chatView.contentY + chatView.height
 
-            property bool newlyShown: shown &&
-                                      messageModel.lastShownIndex !== -1 &&
-                                      index > messageModel.lastShownIndex
-
-            function promoteLastShownIndex() {
-                if (index > messageModel.lastShownIndex) {
-                    // This doesn't promote the read marker, only the shown
-                    // index in the model. The read marker is updated upon
-                    // activity of the user, we have no control over that here.
-                    messageModel.lastShownIndex = index
-                    console.log("Updated last shown index to #" + index,
-                                "event id", eventId)
-                }
-            }
-
-            Timer {
-                id: indexPromotionTimer
-                interval: 1000
-                onTriggered: { if (parent.shown) promoteLastShownIndex() }
-            }
-
-            onShownChanged: {
-                if (messageModel.room.readMarkerEventId === eventId)
-                {
-                    if (shown)
-                        promoteLastShownIndex()
-                    else
-                        messageModel.lastShownIndex = -1
-                }
-            }
-
-            onNewlyShownChanged: {
-                // Only promote the shown index if it's been initialised from
-                // the read marker beforehand, and only if the message has been
-                // on screen for some time.
-                if (newlyShown)
-                {
-                    indexPromotionTimer.start()
-                    console.log("Scheduled lastReadIndex update from",
-                                messageModel.lastShownIndex, "to", index,
-                                "in", indexPromotionTimer.interval, "ms")
-                }
-            }
+            onShownChanged:
+                messageModel.onEventShownChanged(index, eventId, shown)
 
             RowLayout {
                 id: message

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -12,7 +12,7 @@ Rectangle {
 
     signal getPreviousContent()
 
-    Timer{
+    Timer {
         id: scrollTimer
         interval: 0
         onTriggered: reallyScrollToBottom()
@@ -47,12 +47,12 @@ Rectangle {
 
         function rowsInserted() {
             if( stickToBottom )
-                root.scrollToBottom();
+                root.scrollToBottom()
         }
 
         Component.onCompleted: {
-            console.log("onCompleted");
-            model.rowsInserted.connect(rowsInserted);
+            console.log("onCompleted")
+            model.rowsInserted.connect(rowsInserted)
         }
 
         section {
@@ -69,29 +69,29 @@ Rectangle {
 
         onHeightChanged: {
             if( stickToBottom )
-                root.scrollToBottom();
+                root.scrollToBottom()
         }
 
         onContentHeightChanged: {
             if( stickToBottom )
-                root.scrollToBottom();
+                root.scrollToBottom()
         }
 
         onContentYChanged: {
             if( (this.contentY - this.originY) < 5 )
             {
-                console.log("get older content!");
+                console.log("get older content!")
                 root.getPreviousContent()
             }
 
         }
 
         onMovementStarted: {
-            stickToBottom = false;
+            stickToBottom = false
         }
 
         onMovementEnded: {
-            stickToBottom = nowAtYEnd;
+            stickToBottom = nowAtYEnd
         }
 
     }
@@ -216,9 +216,9 @@ Rectangle {
 
                         TextEdit {
                             id: contentField
-                            selectByMouse: true; readOnly: true; font: timelabel.font;
+                            selectByMouse: true; readOnly: true; font: timelabel.font
                             textFormat: contentType == "text/html" ? TextEdit.RichText
-                                                                   : TextEdit.PlainText;
+                                                                   : TextEdit.PlainText
                             text: eventType != "image" ? content : ""
                             height: eventType != "image" ? implicitHeight : 0
                             wrapMode: Text.Wrap; width: parent.width
@@ -286,16 +286,16 @@ Rectangle {
         }
     }
     Rectangle {
-        id: scrollindicator;
+        id: scrollindicator
         opacity: chatView.nowAtYEnd ? 0 : 0.5
         color: defaultPalette.text
-        height: 30;
-        radius: height/2;
-        width: height;
-        anchors.left: parent.left;
-        anchors.bottom: parent.bottom;
-        anchors.leftMargin: width/2;
-        anchors.bottomMargin: chatView.nowAtYEnd ? -height : height/2;
+        height: 30
+        radius: height/2
+        width: height
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: width/2
+        anchors.bottomMargin: chatView.nowAtYEnd ? -height : height/2
         Behavior on opacity {
             NumberAnimation { duration: 300 }
         }

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -139,11 +139,11 @@ Rectangle {
                 y + message.height - 1 < chatView.contentY + chatView.height
 
             property bool newlyShown: shown &&
-                                      messageModel.lastShownIndex != -1 &&
+                                      messageModel.lastShownIndex !== -1 &&
                                       index > messageModel.lastShownIndex
 
             function promoteLastShownIndex() {
-                if (shown && index > messageModel.lastShownIndex) {
+                if (index > messageModel.lastShownIndex) {
                     // This doesn't promote the read marker, only the shown
                     // index in the model. The read marker is updated upon
                     // activity of the user, we have no control over that here.
@@ -156,12 +156,17 @@ Rectangle {
             Timer {
                 id: indexPromotionTimer
                 interval: 1000
-                onTriggered: promoteLastShownIndex()
+                onTriggered: { if (parent.shown) promoteLastShownIndex() }
             }
 
             onShownChanged: {
                 if (messageModel.room.readMarkerEventId === eventId)
-                    promoteLastShownIndex()
+                {
+                    if (shown)
+                        promoteLastShownIndex()
+                    else
+                        messageModel.lastShownIndex = -1
+                }
             }
 
             onNewlyShownChanged: {

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -20,7 +20,6 @@
 #include "quaternionroom.h"
 
 #include "message.h"
-#include "lib/events/event.h"
 #include "lib/connection.h"
 
 #include <QtCore/QDebug>
@@ -29,7 +28,6 @@ QuaternionRoom::QuaternionRoom(QMatrixClient::Connection* connection, QString ro
     : QMatrixClient::Room(connection, roomId)
 {
     m_shown = false;
-    m_unreadMessages = false;
     m_cachedInput = "";
     connect( this, &QuaternionRoom::notificationCountChanged, this, &QuaternionRoom::countChanged );
     connect( this, &QuaternionRoom::highlightCountChanged, this, &QuaternionRoom::countChanged );
@@ -41,12 +39,6 @@ QuaternionRoom::~QuaternionRoom()
 void QuaternionRoom::lookAt()
 {
     markMessagesAsRead();
-    if( m_unreadMessages )
-    {
-        m_unreadMessages = false;
-        emit unreadMessagesChanged(this);
-        qDebug() << displayName() << "no unread messages";
-    }
 }
 
 void QuaternionRoom::setShown(bool shown)
@@ -71,11 +63,6 @@ const QuaternionRoom::Timeline& QuaternionRoom::messages() const
     return m_messages;
 }
 
-bool QuaternionRoom::hasUnreadMessages()
-{
-    return m_unreadMessages;
-}
-
 inline Message* QuaternionRoom::makeMessage(QMatrixClient::Event* e)
 {
     return new Message(connection(), e, this);
@@ -86,25 +73,8 @@ void QuaternionRoom::doAddNewMessageEvents(const QMatrixClient::Events& events)
     Room::doAddNewMessageEvents(events);
 
     m_messages.reserve(m_messages.size() + events.size());
-    bool new_message = false;
-    QMatrixClient::Event* lastOwnMessage = nullptr;
     for (auto e: events)
-    {
         m_messages.push_back(makeMessage(e));
-        if (e->senderId() == connection()->userId())
-            lastOwnMessage = e;
-        else if (e->type() == QMatrixClient::EventType::RoomMessage)
-            new_message = true;
-    }
-    if (lastOwnMessage)
-        promoteReadMarker(connection()->user(), lastOwnMessage->id());
-
-    if( !m_unreadMessages && new_message)
-    {
-        m_unreadMessages = true;
-        emit unreadMessagesChanged(this);
-        qDebug() << "Room" << displayName() << ": unread messages";
-    }
 }
 
 void QuaternionRoom::doAddHistoricalMessageEvents(const QMatrixClient::Events& events)
@@ -114,29 +84,6 @@ void QuaternionRoom::doAddHistoricalMessageEvents(const QMatrixClient::Events& e
     m_messages.reserve(m_messages.size() + events.size());
     for (auto e: events)
         m_messages.push_front(makeMessage(e));
-}
-
-void QuaternionRoom::processEphemeralEvent(QMatrixClient::Event* event)
-{
-    QMatrixClient::Room::processEphemeralEvent(event);
-    if ( m_unreadMessages && event->type() == QMatrixClient::EventType::Receipt )
-    {
-        QString lastReadId = lastReadEvent(connection()->user());
-        // Older Qt doesn't provide QVector::rbegin()/rend()
-        for (auto it = messageEvents().end(); it != messageEvents().begin(); )
-        {
-            --it;
-            if ( lastReadId == (*it)->id() )
-            {
-                m_unreadMessages = false;
-                emit unreadMessagesChanged(this);
-                qDebug() << displayName() << "no unread messages";
-                break;
-            }
-            if ( (*it)->type() == QMatrixClient::EventType::RoomMessage )
-                break;
-        }
-    }
 }
 
 void QuaternionRoom::countChanged()

--- a/client/quaternionroom.h
+++ b/client/quaternionroom.h
@@ -29,7 +29,6 @@ class QuaternionRoom: public QMatrixClient::Room
         Q_OBJECT
     public:
         using Timeline = QMatrixClient::Owning< QList<Message*> >;
-        using size_type = Timeline::size_type;
 
         QuaternionRoom(QMatrixClient::Connection* connection, QString roomId);
         ~QuaternionRoom();

--- a/client/quaternionroom.h
+++ b/client/quaternionroom.h
@@ -47,17 +47,9 @@ class QuaternionRoom: public QMatrixClient::Room
 
         const Timeline& messages() const;
 
-        bool hasUnreadMessages();
-
-    signals:
-        void aboutToInsertMessages(size_type from, size_type to);
-        void insertedMessages();
-        void unreadMessagesChanged(QuaternionRoom* room);
-
     protected:
         virtual void doAddNewMessageEvents(const QMatrixClient::Events& events) override;
         virtual void doAddHistoricalMessageEvents(const QMatrixClient::Events& events) override;
-        virtual void processEphemeralEvent(QMatrixClient::Event* event) override;
 
     private slots:
         void countChanged();
@@ -65,7 +57,6 @@ class QuaternionRoom: public QMatrixClient::Room
     private:
         Timeline m_messages;
         bool m_shown;
-        bool m_unreadMessages;
         QString m_cachedInput;
 
         Message* makeMessage(QMatrixClient::Event* e);


### PR DESCRIPTION
This is the more accurate read marker implementation. Specifically, it tracks which messages in the room can actually be seen at the moment and marks only those messages as read. Moreover, it only starts marking messages as read from the moment when the read marker appears on the screen. So the overall logic is now as follows:

- If the most recent read message is off the screen, no messages are marked as _shown_ or _read_.
- When the read marker is on the screen, messages until it are immediately marked as _shown_. Messages that are on the screen but below the read marker are marked as _shown_ after 1 second of staying on the screen.
- When the activity detector detects user interaction, all _shown_ messages are marked as _read_.
- There's a special behaviour for messages from the local user: they're automatically marked as _read_ but only if they're among already _read_ others' messages or if they _immediately_ follow the most recent message not from a local user.

Besides, probably, some fine-tuning of `ActivityDetector`, I consider this implementation production-ready. @maralorn, your input on `ActivityDetector` as well as on this PR, is much welcome.

Warning: this PR needs a change in libqmatrixclient that is not in `master` yet: Fxrh/libqmatrixclient#48. Once the libqmatrixclient PR is approved, the current PR will be updated to refer to `master`.

Fixes #110.