### PR TITLE
Show messagebox after trying to join an invalid room

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -194,14 +194,8 @@ void ChatRoomWidget::sendLine()
     // Commands available without current room
     if( text.startsWith("/join") )
     {
-        QString roomName = text.section(' ', 1, 1, QString::SectionSkipEmpty);
-        if( !roomName.isEmpty() )
-            m_currentConnection->joinRoom( roomName );
-        else
-        {
-            qDebug() << "No arguments for /join, going interactive";
-            emit joinRoomNeedsInteraction();
-        }
+        const QString roomName = text.section(' ', 1, 1, QString::SectionSkipEmpty);
+        emit joinCommandEntered(roomName);
     }
     else // Commands available only in the room context
         if (m_currentRoom)

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -49,7 +49,7 @@ class ChatRoomWidget: public QWidget
         void lookAtRoom();
 
     signals:
-        void joinRoomNeedsInteraction();
+        void joinCommandEntered(const QString& roomAlias);
         void showStatusMessage(const QString& message, int timeout);
 
     public slots:

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -24,6 +24,7 @@
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMenuBar>
 #include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
 #include <QtWidgets/QAction>
 #include <QtWidgets/QInputDialog>
 #include <QtWidgets/QStatusBar>
@@ -164,6 +165,7 @@ void MainWindow::setConnection(QuaternionConnection* newConnection)
         connect( connection, &Connection::reconnected, this, &MainWindow::getNewEvents );
         connect( connection, &Connection::loginError, this, &MainWindow::loggedOut );
         connect( connection, &Connection::loggedOut, [=]{ loggedOut(); } );
+        connect( connection, &Connection::invalidRoom, this, &MainWindow::showInvalidRoomDialog );
     }
 }
 
@@ -277,6 +279,14 @@ void MainWindow::showJoinRoomDialog()
     {
         connection->joinRoom(room);
     }
+}
+
+void MainWindow::showInvalidRoomDialog(const QString& roomAlias) const
+{
+    QMessageBox messageBox;
+    messageBox.setText(tr("The room %1 does not seem to exist.").arg(roomAlias));
+    messageBox.setIcon(QMessageBox::Warning);
+    messageBox.exec();
 }
 
 

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -242,13 +242,10 @@ void MainWindow::initialSync()
 
 void MainWindow::joinRoom(const QString& roomAlias)
 {
-    const QString room = [=] {
-        if (!roomAlias.isEmpty())
-            return roomAlias;
-
-        return QInputDialog::getText(this, tr("Join Room"), tr("Enter the name of the room"),
+    QString room = roomAlias;
+    if (room.isEmpty())
+        room = QInputDialog::getText(this, tr("Join Room"), tr("Enter the name of the room"),
                                      QLineEdit::Normal, QString());
-    }();
 
     // Dialog rejected, nothing to do.
     if (room.isEmpty())

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -52,13 +52,13 @@ class MainWindow: public QMainWindow
     private slots:
         void initialize();
         void initialSync();
+        void joinRoom(const QString& roomAlias = QString());
         void getNewEvents();
         void gotEvents();
         void loggedOut(const QString& message = QString());
 
         void connectionError(QString error);
 
-        void showJoinRoomDialog();
         void showLoginWindow(const QString& statusMessage = QString());
         void logout();
 

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -59,7 +59,6 @@ class MainWindow: public QMainWindow
         void connectionError(QString error);
 
         void showJoinRoomDialog();
-        void showInvalidRoomDialog(const QString& roomAlias) const;
         void showLoginWindow(const QString& statusMessage = QString());
         void logout();
 

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -59,6 +59,7 @@ class MainWindow: public QMainWindow
         void connectionError(QString error);
 
         void showJoinRoomDialog();
+        void showInvalidRoomDialog(const QString& roomAlias) const;
         void showLoginWindow(const QString& statusMessage = QString());
         void logout();
 


### PR DESCRIPTION
If the room the user is trying to join is invalid, show a messagebox
with a warning message instead of doing nothing.

Fixes #128