### PR TITLE
Add ToolTipRole to UserListModel

### DIFF
--- a/client/models/userlistmodel.cpp
+++ b/client/models/userlistmodel.cpp
@@ -87,6 +87,12 @@ QVariant UserListModel::data(const QModelIndex& index, int role) const
     {
         return user->avatar(25,25);
     }
+
+    if (role == Qt::ToolTipRole)
+    {
+        return QStringLiteral("<b>%1</b><br>%2").arg(user->name(), user->id());
+    }
+
     return QVariant();
 }
 


### PR DESCRIPTION
The tooltip will be useful to quickly retrieve the matrix id of any
user. This also means we can just show `user->name()` instead of
`roomMemberName()`, otherwise the matrix id would be shown twice for
users who have the same id.