### PR TITLE
Add separator between topic and chat widgets

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -94,6 +94,8 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     connect( m_chatEdit, &QLineEdit::returnPressed, this, &ChatRoomWidget::sendLine );
 
     m_currentlyTyping = new QLabel();
+    m_topicSeparator = new QFrame(this);
+    m_topicSeparator->setFrameShape(QFrame::HLine);
     m_topicLabel = new QLabel();
     m_topicLabel->setWordWrap(true);
     m_topicLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
@@ -101,6 +103,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
 
     QVBoxLayout* layout = new QVBoxLayout();
     layout->addWidget(m_topicLabel);
+    layout->addWidget(m_topicSeparator);
     layout->addWidget(container);
     layout->addWidget(m_currentlyTyping);
     layout->addWidget(m_chatEdit);

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -94,8 +94,8 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     connect( m_chatEdit, &QLineEdit::returnPressed, this, &ChatRoomWidget::sendLine );
 
     m_currentlyTyping = new QLabel();
-    m_topicSeparator = new QFrame(this);
-    m_topicSeparator->setFrameShape(QFrame::HLine);
+    auto topicSeparator = new QFrame(this);
+    topicSeparator->setFrameShape(QFrame::HLine);
     m_topicLabel = new QLabel();
     m_topicLabel->setWordWrap(true);
     m_topicLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
@@ -103,7 +103,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
 
     QVBoxLayout* layout = new QVBoxLayout();
     layout->addWidget(m_topicLabel);
-    layout->addWidget(m_topicSeparator);
+    layout->addWidget(topicSeparator);
     layout->addWidget(container);
     layout->addWidget(m_currentlyTyping);
     layout->addWidget(m_chatEdit);

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -31,6 +31,7 @@ namespace QMatrixClient
 class MessageEventModel;
 class QuaternionRoom;
 class ImageProvider;
+class QFrame;
 class QQuickView;
 class QListView;
 class QLineEdit;
@@ -81,4 +82,5 @@ class ChatRoomWidget: public QWidget
         QLineEdit* m_chatEdit;
         QLabel* m_currentlyTyping;
         QLabel* m_topicLabel;
+        QFrame* m_topicSeparator;
 };

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -82,5 +82,4 @@ class ChatRoomWidget: public QWidget
         QLineEdit* m_chatEdit;
         QLabel* m_currentlyTyping;
         QLabel* m_topicLabel;
-        QFrame* m_topicSeparator;
 };


### PR DESCRIPTION
Otherwise it may not be clear that the date is part of the chat and not
the last line of the topic.