### PR TITLE
Make read marker more robust and lighter on resources

### DIFF
--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -154,8 +154,12 @@ Rectangle {
                 y + message.height - 1 > chatView.contentY &&
                 y + message.height - 1 < chatView.contentY + chatView.height
 
+            Component.onCompleted:
+                if (shown)
+                    messageModel.onMessageShownChanged(eventId, shown)
+
             onShownChanged:
-                messageModel.onEventShownChanged(index, eventId, shown)
+                messageModel.onMessageShownChanged(eventId, shown)
 
             RowLayout {
                 id: message


### PR DESCRIPTION
Improvements to the code in onMessageShownChanged (former onEventShownChanged):
1. The code doesn't spawn a separate timer for each event/message anymore; a single timer runs at any point in time now, that only tracks the bottommost message
2. There's a single sorted vector for shown messages bookkeeping now, instead of two hash-tables.
3. The code doesn't depend on the model/QML's index - the index may change as new messages get loaded, leading to inaccuracies. The new code also doesn't assume that the read marker only moves down and that it is only updated from the same client.