### PR TITLE
Detect activity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(quaternion_SRCS
     client/quaternionroom.cpp
     client/message.cpp
     client/imageprovider.cpp
+    client/activitydetector.cpp
     client/logindialog.cpp
     client/mainwindow.cpp
     client/roomlistdock.cpp

--- a/client/activitydetector.cpp
+++ b/client/activitydetector.cpp
@@ -1,0 +1,73 @@
+/**************************************************************************
+ *                                                                        *
+ * Copyright (C) 2016 Malte Brandy <malte.brandy@maralorn.de>                        *
+ *                                                                        *
+ * This program is free software; you can redistribute it and/or          *
+ * modify it under the terms of the GNU General Public License            *
+ * as published by the Free Software Foundation; either version 3         *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * This program is distributed in the hope that it will be useful,        *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ * GNU General Public License for more details.                           *
+ *                                                                        *
+ * You should have received a copy of the GNU General Public License      *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                        *
+ **************************************************************************/
+
+#include "activitydetector.h"
+
+#include <QtCore/QDebug>
+
+#include "mainwindow.h"
+#include "chatroomwidget.h"
+
+ActivityDetector::ActivityDetector(QApplication& a, MainWindow& w)
+    : m_app(a)
+    , m_mainWindow(w)
+    , m_enabled(false)
+{
+    const auto chatWidget = w.getChatRoomWidget();
+    connect( chatWidget, &ChatRoomWidget::readMarkerMoved,
+             this, &ActivityDetector::updateEnabled );
+    connect( chatWidget, &ChatRoomWidget::readMarkerCandidateMoved,
+             this, &ActivityDetector::updateEnabled );
+    connect( this, &ActivityDetector::triggered,
+             chatWidget, &ChatRoomWidget::markShownAsRead );
+}
+
+void ActivityDetector::updateEnabled()
+{
+    setEnabled(m_mainWindow.getChatRoomWidget()->pendingMarkRead());
+}
+
+void ActivityDetector::setEnabled(bool enabled)
+{
+    if (enabled == m_enabled)
+        return;
+
+    m_enabled = enabled;
+    m_mainWindow.setMouseTracking(enabled);
+    if (enabled)
+        m_app.installEventFilter(this);
+    else
+        m_app.removeEventFilter(this);
+    qDebug() << "Activity Detector enabled:" << enabled;
+}
+
+bool ActivityDetector::eventFilter(QObject* obj, QEvent* ev)
+{
+    switch (ev->type())
+    {
+    case QEvent::KeyPress:
+    case QEvent::FocusIn:
+    case QEvent::MouseMove:
+    case QEvent::MouseButtonPress:
+        emit triggered();
+        break;
+    default:;
+    }
+    return QObject::eventFilter(obj, ev);
+}

--- a/client/activitydetector.h
+++ b/client/activitydetector.h
@@ -1,0 +1,47 @@
+/**************************************************************************
+ *                                                                        *
+ * Copyright (C) 2016 Malte Brandy <malte.brandy@maralorn.de>                        *
+ *                                                                        *
+ * This program is free software; you can redistribute it and/or          *
+ * modify it under the terms of the GNU General Public License            *
+ * as published by the Free Software Foundation; either version 3         *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * This program is distributed in the hope that it will be useful,        *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ * GNU General Public License for more details.                           *
+ *                                                                        *
+ * You should have received a copy of the GNU General Public License      *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                        *
+ **************************************************************************/
+
+#pragma once
+
+#include <QtWidgets/QApplication>
+
+class MainWindow;
+
+class ActivityDetector : public QObject
+{
+    Q_OBJECT
+
+    public:
+        ActivityDetector(QApplication& a, MainWindow& c);
+
+    public slots:
+        void updateEnabled();
+        void setEnabled(bool enabled);
+
+    signals:
+        void triggered();
+
+    protected:
+        bool eventFilter(QObject* obj, QEvent* ev);
+
+    private:
+        QApplication& m_app;
+        MainWindow& m_mainWindow;
+        bool m_enabled;
+};

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -142,8 +142,15 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
         m_chatEdit->setText( m_currentRoom->cachedInput() );
         connect( m_currentRoom, &QMatrixClient::Room::typingChanged, this, &ChatRoomWidget::typingChanged );
         connect( m_currentRoom, &QMatrixClient::Room::topicChanged, this, &ChatRoomWidget::topicChanged );
-        connect( m_currentRoom, &QMatrixClient::Room::readMarkerMoved,
-                 this, &ChatRoomWidget::readMarkerMoved );
+        connect( m_currentRoom, &QMatrixClient::Room::readMarkerMoved, [=] {
+            const auto rm = m_currentRoom->readMarker();
+            readMarkerOnScreen =
+                rm != m_currentRoom->timelineEdge() &&
+                std::lower_bound( indicesOnScreen.begin(), indicesOnScreen.end(),
+                                 rm->index() ) != indicesOnScreen.end();
+            reStartShownTimer();
+            emit readMarkerMoved();
+        });
         m_currentRoom->setShown(true);
         topicChanged();
         typingChanged();

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -86,6 +86,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     QQmlContext* ctxt = m_quickView->rootContext();
     ctxt->setContextProperty("messageModel", m_messageModel);
+    ctxt->setContextProperty("controller", this);
     ctxt->setContextProperty("debug", QVariant(false));
     m_quickView->setSource(QUrl("qrc:///qml/chat.qml"));
     m_quickView->setResizeMode(QQuickView::SizeRootObjectToView);

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -142,7 +142,7 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
         m_chatEdit->setText( m_currentRoom->cachedInput() );
         connect( m_currentRoom, &QMatrixClient::Room::typingChanged, this, &ChatRoomWidget::typingChanged );
         connect( m_currentRoom, &QMatrixClient::Room::topicChanged, this, &ChatRoomWidget::topicChanged );
-        connect( m_currentRoom, &QMatrixClient::Room::readMarkerMoved, [=] {
+        connect( m_currentRoom, &QMatrixClient::Room::readMarkerMoved, this, [this] {
             const auto rm = m_currentRoom->readMarker();
             readMarkerOnScreen =
                 rm != m_currentRoom->timelineEdge() &&

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -94,7 +94,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     connect( m_chatEdit, &QLineEdit::returnPressed, this, &ChatRoomWidget::sendLine );
 
     m_currentlyTyping = new QLabel();
-    auto topicSeparator = new QFrame(this);
+    auto topicSeparator = new QFrame();
     topicSeparator->setFrameShape(QFrame::HLine);
     m_topicLabel = new QLabel();
     m_topicLabel->setWordWrap(true);

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -20,16 +20,11 @@
 #pragma once
 
 #include <QtWidgets/QWidget>
+#include <QtCore/QBasicTimer>
 
-namespace QMatrixClient
-{
-    class Room;
-    class Connection;
-    class User;
-    class Event;
-}
+#include "quaternionroom.h"
+
 class MessageEventModel;
-class QuaternionRoom;
 class ImageProvider;
 class QFrame;
 class QQuickView;
@@ -58,6 +53,11 @@ class ChatRoomWidget: public QWidget
         void setConnection(QMatrixClient::Connection* connection);
         void topicChanged();
         void typingChanged();
+        void onMessageShownChanged(QString eventId, bool shown);
+        void markShownAsRead();
+
+    protected:
+        void timerEvent(QTimerEvent* event) override;
 
     private slots:
         void sendLine();
@@ -82,4 +82,12 @@ class ChatRoomWidget: public QWidget
         QLineEdit* m_chatEdit;
         QLabel* m_currentlyTyping;
         QLabel* m_topicLabel;
+
+        using timeline_index_t = QMatrixClient::TimelineItem::index_t;
+        QVector<timeline_index_t> indicesOnScreen;
+        timeline_index_t indexToMaybeRead;
+        QBasicTimer maybeReadTimer;
+        bool readMarkerOnScreen;
+
+        void reStartShownTimer();
 };

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -42,11 +42,13 @@ class ChatRoomWidget: public QWidget
         void enableDebug();
         void triggerCompletion();
         void cancelCompletion();
-        void lookAtRoom();
+        bool pendingMarkRead() const;
 
     signals:
         void joinCommandEntered(const QString& roomAlias);
         void showStatusMessage(const QString& message, int timeout = 0);
+        void readMarkerMoved();
+        void readMarkerCandidateMoved();
 
     public slots:
         void setRoom(QuaternionRoom* room);

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -51,7 +51,7 @@ class ChatRoomWidget: public QWidget
 
     signals:
         void joinCommandEntered(const QString& roomAlias);
-        void showStatusMessage(const QString& message, int timeout);
+        void showStatusMessage(const QString& message, int timeout = 0);
 
     public slots:
         void setRoom(QuaternionRoom* room);

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -22,32 +22,7 @@
 #include <QtCore/QDebug>
 
 #include "mainwindow.h"
-
-class ActivityDetector : public QObject
-{
-    public:
-        ActivityDetector(MainWindow* c): m_mainWindow(c)
-        {
-            c->setMouseTracking(true);
-        };
-    protected:
-        bool eventFilter(QObject* obj, QEvent* ev)
-        {
-            switch (ev->type())
-            {
-            case QEvent::KeyPress:
-            case QEvent::FocusIn:
-            case QEvent::MouseMove:
-            case QEvent::MouseButtonPress:
-                m_mainWindow->activity();
-            default:;
-            }
-            return QObject::eventFilter(obj, ev);
-        }
-    private:
-        MainWindow* m_mainWindow;
-};
-
+#include "activitydetector.h"
 
 int main( int argc, char* argv[] )
 {
@@ -79,8 +54,7 @@ int main( int argc, char* argv[] )
     MainWindow window;
     if( debugEnabled )
         window.enableDebug();
-    ActivityDetector ad(&window);
-    app.installEventFilter(&ad);
+    ActivityDetector ad(app, window); Q_UNUSED(ad);
     window.show();
 
     return app.exec();

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -69,9 +69,9 @@ MainWindow::~MainWindow()
 {
 }
 
-void MainWindow::activity()
+ChatRoomWidget* MainWindow::getChatRoomWidget() const
 {
-    chatRoomWidget->lookAtRoom();
+   return chatRoomWidget;
 }
 
 void MainWindow::createMenu()

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -42,9 +42,9 @@ class MainWindow: public QMainWindow
         virtual ~MainWindow();
 
         void enableDebug();
-        void activity();
 
         void setConnection(QuaternionConnection* newConnection);
+        ChatRoomWidget* getChatRoomWidget() const;
 
     protected:
         virtual void closeEvent(QCloseEvent* event) override;

--- a/client/models/messageeventmodel.h
+++ b/client/models/messageeventmodel.h
@@ -20,9 +20,8 @@
 #pragma once
 
 #include <QtCore/QAbstractListModel>
-#include <QtCore/QBasicTimer>
 
-#include "../quaternionroom.h"
+class QuaternionRoom;
 
 class MessageEventModel: public QAbstractListModel
 {
@@ -43,19 +42,6 @@ class MessageEventModel: public QAbstractListModel
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         QHash<int, QByteArray> roleNames() const override;
 
-    public slots:
-        void onMessageShownChanged(QString eventId, bool shown);
-        void markShownAsRead();
-
-    protected:
-        void timerEvent(QTimerEvent* event) override;
-
     private:
         QuaternionRoom* m_currentRoom;
-
-        QVector<QMatrixClient::TimelineItem::index_t> indicesOnScreen;
-        QuaternionRoom::rev_iter_t maybeReadMessage;
-        QBasicTimer maybeReadTimer;
-
-        void reStartShownTimer();
 };

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -154,12 +154,13 @@ Rectangle {
                 y + message.height - 1 > chatView.contentY &&
                 y + message.height - 1 < chatView.contentY + chatView.height
 
-            Component.onCompleted:
+            Component.onCompleted: {
                 if (shown)
-                    messageModel.onMessageShownChanged(eventId, shown)
+                    shownChanged(true);
+            }
 
             onShownChanged:
-                messageModel.onMessageShownChanged(eventId, shown)
+                controller.onMessageShownChanged(eventId, shown)
 
             RowLayout {
                 id: message

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -154,8 +154,12 @@ Rectangle {
                 y + message.height - 1 > chatView.contentY &&
                 y + message.height - 1 < chatView.contentY + chatView.height
 
+            Component.onCompleted:
+                if (shown)
+                    messageModel.onMessageShownChanged(eventId, shown)
+
             onShownChanged:
-                messageModel.onEventShownChanged(index, eventId, shown)
+                messageModel.onMessageShownChanged(eventId, shown)
 
             RowLayout {
                 id: message

--- a/client/qml/chat.qml
+++ b/client/qml/chat.qml
@@ -213,6 +213,18 @@ Rectangle {
                                 cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
                                 acceptedButtons: Qt.NoButton
                             }
+
+                            // TODO: In the code below, links should be resolved
+                            // with Qt.resolvedLink, once we figure out what
+                            // to do with relative URLs (note: www.google.com
+                            // is a relative URL, https://www.google.com is not).
+                            // Instead of Qt.resolvedUrl (and, most likely,
+                            // QQmlAbstractUrlInterceptor to convert URLs)
+                            // we might just prefer to do the whole resolving
+                            // in C++.
+                            onHoveredLinkChanged:
+                                controller.showStatusMessage(hoveredLink)
+
                             onLinkActivated: {
                                 Qt.openUrlExternally(link)
                             }


### PR DESCRIPTION
As there seem to be no reviewers around, I'm encompassing 3 PRs into one to save on bureaucracy; besides, all these actually revolve around the same code. These are:

1. First commit rewrites the shown messages tracking code.
1. The following two move this code out of `MessageEventModel` to `ChatRoomWidget`. The model never seemed to be the right place for such things but we didn't have the chat widget as a context property in QML, so used the model to callback for things.
1. The last two improve `ActivityDetector` - this is basically the code by @maralorn rebased on the newest master and tweaked in some places. Naturally, it doesn't deal with the model anymore, only with the chat widget.