### PR TITLE
Linkify at least some URLs even in plain text messages

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -98,8 +98,11 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     auto topicSeparator = new QFrame(this);
     topicSeparator->setFrameShape(QFrame::HLine);
     m_topicLabel = new QLabel();
+    m_topicLabel->setTextFormat(Qt::RichText);
     m_topicLabel->setWordWrap(true);
-    m_topicLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_topicLabel->setTextInteractionFlags(Qt::TextBrowserInteraction
+                                          |Qt::TextSelectableByKeyboard);
+    m_topicLabel->setOpenExternalLinks(true);
 
 
     QVBoxLayout* layout = new QVBoxLayout();
@@ -183,7 +186,7 @@ void ChatRoomWidget::typingChanged()
 
 void ChatRoomWidget::topicChanged()
 {
-    m_topicLabel->setText( m_currentRoom->topic() );
+    m_topicLabel->setText( m_currentRoom->prettyTopic() );
 }
 
 void ChatRoomWidget::sendLine()

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -21,6 +21,7 @@
 
 #include <QtCore/QTimerEvent>
 #include <QtCore/QSettings>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QDebug>
 
 #include "../message.h"
@@ -110,6 +111,44 @@ int MessageEventModel::rowCount(const QModelIndex& parent) const
     if( !m_currentRoom || parent.isValid() )
         return 0;
     return m_currentRoom->messages().count();
+}
+
+void linkifyUrls(QString& text)
+{
+    static const auto RegExpOptions =
+        QRegularExpression::CaseInsensitiveOption
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
+        | QRegularExpression::OptimizeOnFirstUsageOption
+#endif
+        | QRegularExpression::UseUnicodePropertiesOption;
+    static const QRegularExpression urlDetectorMail {
+        "(^|\\s)(" // Criteria to match the beginning of the URL
+            "\\w[^@\\s]*@" // authority (the part before @)
+            "(\\w[-\\w]*\\.)+\\w[-\\w]+" // host (at least two labels and at least two letters in tld)
+        "\\b)", // Criteria to match the end of the URL
+        RegExpOptions
+    };
+    static const QRegularExpression urlDetectorRelative {
+        "(^|\\s)(" // Criteria to match the beginning of the URL
+            "(\\w[-\\w]*\\.)+\\w[-\\w]+" // host (at least two labels and at least two letters in tld)
+        "\\b)", // Criteria to match the end of the URL
+        RegExpOptions
+    };
+    static const QRegularExpression urlDetectorAbsolute {
+        "(^|\\s)(" // Criteria to match the beginning of the URL
+            "(?!file)(\\w+:(//)?)" // schema
+            "(\\w[^@\\s]*@)?" // optional authority (the part before @)
+            "(\\w[-\\w]*\\.?)+" // host (non quite strict)
+            "(:\\d{1,5})?" // optional port
+            "(/[^\\s]*)?" // optional query and fragment
+        "\\b)", // Criteria to match the end of the URL
+        RegExpOptions
+    };
+    // mail regex is the least specific because of [^@\\s], run it first to
+    // avoid repeated substitutions.
+    text.replace(urlDetectorMail, "\\1<a href=\"mailto:\\2\">\\2</a>");
+    text.replace(urlDetectorRelative, "\\1<a href=\"http://\\2\">\\2</a>");
+    text.replace(urlDetectorAbsolute, "\\1<a href=\"\\2\">\\2</a>");
 }
 
 QVariant MessageEventModel::data(const QModelIndex& index, int role) const
@@ -212,25 +251,16 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
             case MessageEventType::Emote:
             case MessageEventType::Text:
             case MessageEventType::Notice:
-                {
-                    QString body;
-                    QString contentType;
+                if (role == ContentTypeRole)
+                    return "text/html";
+                else {
                     auto textContent = static_cast<TextContent*>(e->content());
                     if (textContent && textContent->mimeType.inherits("text/html"))
-                    {
-                        body = textContent->body;
-                        contentType = "text/html";
-                    }
-                    else
-                    {
-                        body = e->plainBody();
-                        contentType = "text/plain";
-                    }
+                        return textContent->body;
 
-                    if (role == ContentRole)
-                        return body;
-                    else
-                        return contentType;
+                    auto body = e->plainBody().toHtmlEscaped();
+                    linkifyUrls(body);
+                    return body;
                 }
             case MessageEventType::Image:
                 {

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -122,33 +122,36 @@ void linkifyUrls(QString& text)
 #endif
         | QRegularExpression::UseUnicodePropertiesOption;
     static const QRegularExpression urlDetectorMail {
-        "(^|\\s)(" // Criteria to match the beginning of the URL
+        QStringLiteral("(^|\\s)(" // Criteria to match the beginning of the URL
             "\\w[^@\\s]*@" // authority (the part before @)
             "(\\w[-\\w]*\\.)+\\w[-\\w]+" // host (at least two labels and at least two letters in tld)
-        "\\b)", // Criteria to match the end of the URL
+        "\\b)"), // Criteria to match the end of the URL
         RegExpOptions
     };
     static const QRegularExpression urlDetectorRelative {
-        "(^|\\s)(" // Criteria to match the beginning of the URL
+        QStringLiteral("(^|\\s)(" // Criteria to match the beginning of the URL
             "(\\w[-\\w]*\\.)+\\w[-\\w]+" // host (at least two labels and at least two letters in tld)
-        "\\b)", // Criteria to match the end of the URL
+        "\\b)"), // Criteria to match the end of the URL
         RegExpOptions
     };
     static const QRegularExpression urlDetectorAbsolute {
-        "(^|\\s)(" // Criteria to match the beginning of the URL
+        QStringLiteral("(^|\\s)(" // Criteria to match the beginning of the URL
             "(?!file)(\\w+:(//)?)" // schema
             "(\\w[^@\\s]*@)?" // optional authority (the part before @)
             "(\\w[-\\w]*\\.?)+" // host (non quite strict)
             "(:\\d{1,5})?" // optional port
             "(/[^\\s]*)?" // optional query and fragment
-        "\\b)", // Criteria to match the end of the URL
+        "\\b)"), // Criteria to match the end of the URL
         RegExpOptions
     };
     // mail regex is the least specific because of [^@\\s], run it first to
     // avoid repeated substitutions.
-    text.replace(urlDetectorMail, "\\1<a href=\"mailto:\\2\">\\2</a>");
-    text.replace(urlDetectorRelative, "\\1<a href=\"http://\\2\">\\2</a>");
-    text.replace(urlDetectorAbsolute, "\\1<a href=\"\\2\">\\2</a>");
+    text.replace(urlDetectorMail,
+                 QStringLiteral("\\1<a href=\"mailto:\\2\">\\2</a>"));
+    text.replace(urlDetectorRelative,
+                 QStringLiteral("\\1<a href=\"http://\\2\">\\2</a>"));
+    text.replace(urlDetectorAbsolute,
+                 QStringLiteral("\\1<a href=\"\\2\">\\2</a>"));
 }
 
 QVariant MessageEventModel::data(const QModelIndex& index, int role) const

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -107,13 +107,13 @@ void QuaternionRoom::linkifyUrls(QString& text) const
         | QRegularExpression::OptimizeOnFirstUsageOption
 #endif
         | QRegularExpression::UseUnicodePropertiesOption;
-// A regexp for a full-qualified domain name, as used in schemeless URL regexps below:
-// at least two labels (including TLD), with TLD having at least two characters and
-// starting with a letter (not a digit)
+// A regexp for a full-qualified domain name: at least two labels
+// (including TLD), with TLD having at least two characters and
+// starting with a letter (not a digit).
 #define FQDN "(\\w[-\\w]*\\.)+(?!\\d)\\w[-\\w]+"
     static const QRegularExpression urlDetectorMail {
         QStringLiteral("(^|\\s)(" // Criteria to match the beginning of the URL
-            "\\w[^@\\s]*@" // authority (the part before @)
+            "\\w[^@/#\\s]*@" // authentication (the part before @)
             FQDN
         "\\b)"), // Criteria to match the end of the URL
         RegExpOptions
@@ -123,9 +123,12 @@ void QuaternionRoom::linkifyUrls(QString& text) const
     };
     static const QRegularExpression urlDetectorAbsolute {
         QStringLiteral("(^|\\s)(" // Criteria to match the beginning of the URL
-            "(?!file)(\\w+:(//)?)" // scheme
-            "(\\w[^@\\s]*@)?" // optional authority (the part before @)
-            "(\\w[-\\w]*\\.?)+" // host name or address (non quite strict)
+            "(?!file)([a-z][-.+\\w]+:(//)?)" // scheme
+            "(\\w[^@/#\\s]*@)?" // optional authentication (the part before @)
+            "(" FQDN // host name
+                "|(\\d{1,3}\\.){3}\\d{1,3}" // or IPv4 address (not very strict)
+                "|\\[[\\d:a-f]+\\]" // or IPv6 address (very lazy and not strict)
+            ")"
             "(:\\d{1,5})?" // optional port
             "(/[^\\s]*)?" // optional query and fragment
         "\\b)"), // Criteria to match the end of the URL

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -19,10 +19,9 @@
 
 #include "quaternionroom.h"
 
-#include "message.h"
-#include "lib/connection.h"
+#include <QtCore/QRegularExpression>
 
-#include <QtCore/QDebug>
+#include "message.h"
 
 QuaternionRoom::QuaternionRoom(QMatrixClient::Connection* connection, QString roomId)
     : QMatrixClient::Room(connection, roomId)
@@ -98,4 +97,57 @@ const QString& QuaternionRoom::cachedInput() const
 void QuaternionRoom::setCachedInput(const QString& input)
 {
     m_cachedInput = input;
+}
+
+void QuaternionRoom::linkifyUrls(QString& text) const
+{
+    static const auto RegExpOptions =
+        QRegularExpression::CaseInsensitiveOption
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
+        | QRegularExpression::OptimizeOnFirstUsageOption
+#endif
+        | QRegularExpression::UseUnicodePropertiesOption;
+// A regexp for a full-qualified domain name, as used in schemeless URL regexps below:
+// at least two labels (including TLD), with TLD having at least two characters and
+// starting with a letter (not a digit)
+#define FQDN "(\\w[-\\w]*\\.)+(?!\\d)\\w[-\\w]+"
+    static const QRegularExpression urlDetectorMail {
+        QStringLiteral("(^|\\s)(" // Criteria to match the beginning of the URL
+            "\\w[^@\\s]*@" // authority (the part before @)
+            FQDN
+        "\\b)"), // Criteria to match the end of the URL
+        RegExpOptions
+    };
+    static const QRegularExpression urlDetectorRelative {
+        QStringLiteral("(^|\\s)(" FQDN "\\b)"), RegExpOptions
+    };
+    static const QRegularExpression urlDetectorAbsolute {
+        QStringLiteral("(^|\\s)(" // Criteria to match the beginning of the URL
+            "(?!file)(\\w+:(//)?)" // scheme
+            "(\\w[^@\\s]*@)?" // optional authority (the part before @)
+            "(\\w[-\\w]*\\.?)+" // host name or address (non quite strict)
+            "(:\\d{1,5})?" // optional port
+            "(/[^\\s]*)?" // optional query and fragment
+        "\\b)"), // Criteria to match the end of the URL
+        RegExpOptions
+    };
+#undef FQDN
+    // mail regex is the least specific because of [^@\\s], run it first to
+    // avoid repeated substitutions.
+    text.replace(urlDetectorMail,
+                 QStringLiteral("\\1<a href=\"mailto:\\2\">\\2</a>"));
+    text.replace(urlDetectorRelative,
+                 QStringLiteral("\\1<a href=\"http://\\2\">\\2</a>"));
+    text.replace(urlDetectorAbsolute,
+                 QStringLiteral("\\1<a href=\"\\2\">\\2</a>"));
+}
+
+QString QuaternionRoom::prettyTopic() const
+{
+    QString pt = topic().toHtmlEscaped();
+    if (pt.isEmpty())
+        return QStringLiteral("(no topic)");
+
+    linkifyUrls(pt);
+    return pt;
 }

--- a/client/quaternionroom.h
+++ b/client/quaternionroom.h
@@ -44,6 +44,11 @@ class QuaternionRoom: public QMatrixClient::Room
 
         const Timeline& messages() const;
 
+        /** Converts all that looks like a URL into HTML links */
+        void linkifyUrls(QString& text) const;
+        /** Returns pretty-printed room topic in HTML */
+        QString prettyTopic() const;
+
     protected:
         virtual void doAddNewMessageEvents(const QMatrixClient::Events& events) override;
         virtual void doAddHistoricalMessageEvents(const QMatrixClient::Events& events) override;


### PR DESCRIPTION
Here's the feature long asked for - URLs in plain text bodies are converted to links now. Surprisingly, I haven't found anything pre-cooked to do that; so I crafted 3 regular expressions for specific situations. Obviously there'll be more things like that, with either more regexps introduced or existing ones extended.

There were several potential ways this can be done:
- Alter `MessageEventContent::TextContent` so that it stores the already linkified URL. The worst option since there's no way to get the pristine plain text in this case.
- Alter `MessageEventContent::TextContent` so that it stores both the original plain text and the linkified version. Better but still buries the representational matter in the backend code. If a client wishes to custom-render some URLs (e.g. for internal navigation to rooms, users etc.) this option immediately falls short.
- Linkify URLs in QML - an obvious choice, given that it's a purely representational matter. Unfortunately, closer inspection shows that QML in itself has no means for that; the only option is to import some external JavaScript linkifier. Which can be a way to go but needs further digging. And it's an external dependency for a pretty much niche case. And there's still a problem with those custom-rendered URLs in the future, since Quaternion doesn't have the whole UI in QML.
- Linkify URLs in `MessageEventModel::data()` - this is how I've done it in the end. There's a clear downside here - since I don't use external linkifier library, I had to invent my own regexp's to find URLs. This is of course a [terrible idea](https://stackoverflow.com/a/21925491) but still better in the situation (see the previous bullet about QML).

Closes #124 