### PR TITLE
Improve the tooltip of rooms

### DIFF
--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -125,6 +125,8 @@ QVariant RoomListModel::data(const QModelIndex& index, int role) const
     {
         QString result = QString("<b>%1</b><br>").arg(room->canonicalAlias());
         result += tr("Room users: %1<br>").arg(room->users().count());
+        if (room->highlightCount() > 0)
+            result += tr("Unread mentions: %1<br>").arg(room->highlightCount());
         result += tr("Room ID: %1<br>").arg(room->id());
         if( room->joinState() == QMatrixClient::JoinState::Join )
             result += tr("You joined this room");

--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -124,6 +124,7 @@ QVariant RoomListModel::data(const QModelIndex& index, int role) const
     if( role == Qt::ToolTipRole )
     {
         QString result = QString("<b>%1</b><br>").arg(room->canonicalAlias());
+        result += tr("Room users: %1<br>").arg(room->users().count());
         result += tr("Room ID: %1<br>").arg(room->id());
         if( room->joinState() == QMatrixClient::JoinState::Join )
             result += tr("You joined this room");

--- a/client/models/roomlistmodel.cpp
+++ b/client/models/roomlistmodel.cpp
@@ -123,7 +123,7 @@ QVariant RoomListModel::data(const QModelIndex& index, int role) const
     }
     if( role == Qt::ToolTipRole )
     {
-        QString result = QString("<b>%1</b><br>").arg(room->displayName());
+        QString result = QString("<b>%1</b><br>").arg(room->canonicalAlias());
         result += tr("Room ID: %1<br>").arg(room->id());
         if( room->joinState() == QMatrixClient::JoinState::Join )
             result += tr("You joined this room");


### PR DESCRIPTION
The display name is already shown in the `DisplayRole`. The canonical
alias instead can be useful to disambiguate rooms with the same display
name.