### PR TITLE
Improve chat edit widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(quaternion_SRCS
     client/mainwindow.cpp
     client/roomlistdock.cpp
     client/userlistdock.cpp
+    client/kchatedit.cpp
     client/chatroomwidget.cpp
     client/systemtray.cpp
     client/models/messageeventmodel.cpp

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -18,6 +18,7 @@
  **************************************************************************/
 
 #include "chatroomwidget.h"
+#include "kchatedit.h"
 
 #include <QtCore/QDebug>
 #include <QtWidgets/QLineEdit>
@@ -36,31 +37,6 @@
 #include "quaternionroom.h"
 #include "models/messageeventmodel.h"
 #include "imageprovider.h"
-
-class ChatEdit : public QLineEdit
-{
-    public:
-        ChatEdit(ChatRoomWidget* c);
-    protected:
-        bool event(QEvent *event);
-    private:
-        ChatRoomWidget* m_chatRoomWidget;
-};
-
-ChatEdit::ChatEdit(ChatRoomWidget* c): m_chatRoomWidget(c) {};
-
-bool ChatEdit::event(QEvent *event)
-{
-    if (event->type() == QEvent::KeyPress) {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        if (keyEvent->key() == Qt::Key_Tab) {
-            m_chatRoomWidget->triggerCompletion();
-            return true;
-        } else
-            m_chatRoomWidget->cancelCompletion();
-    }
-    return QLineEdit::event(event);
-}
 
 ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     : QWidget(parent)
@@ -89,9 +65,11 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     m_quickView->setSource(QUrl("qrc:///qml/chat.qml"));
     m_quickView->setResizeMode(QQuickView::SizeRootObjectToView);
 
-    m_chatEdit = new ChatEdit(this);
+    m_chatEdit = new KChatEdit(this);
     m_chatEdit->setPlaceholderText(tr("Send a message (unencrypted)..."));
-    connect( m_chatEdit, &QLineEdit::returnPressed, this, &ChatRoomWidget::sendLine );
+    m_chatEdit->setAcceptRichText(false);
+    m_chatEdit->installEventFilter(this);
+    connect( m_chatEdit, &KChatEdit::inputChanged, this, &ChatRoomWidget::sendLine );
 
     m_currentlyTyping = new QLabel();
     auto topicSeparator = new QFrame();
@@ -133,9 +111,10 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
     indicesOnScreen.clear();
     if( m_currentRoom )
     {
-        m_currentRoom->setCachedInput( m_chatEdit->displayText() );
+        m_currentRoom->setCachedInput( m_chatEdit->toPlainText() );
         m_currentRoom->disconnect( this );
         m_currentRoom->setShown(false);
+        roomHistories.insert(m_currentRoom, m_chatEdit->history());
         if ( m_completing )
             cancelCompletion();
     }
@@ -143,6 +122,7 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
     if( m_currentRoom )
     {
         m_chatEdit->setText( m_currentRoom->cachedInput() );
+        m_chatEdit->setHistory(roomHistories.value(m_currentRoom));
         connect( m_currentRoom, &QMatrixClient::Room::typingChanged, this, &ChatRoomWidget::typingChanged );
         connect( m_currentRoom, &QMatrixClient::Room::topicChanged, this, &ChatRoomWidget::topicChanged );
         connect( m_currentRoom, &QMatrixClient::Room::readMarkerMoved, this, [this] {
@@ -200,7 +180,7 @@ void ChatRoomWidget::sendLine()
     qDebug() << "sendLine";
     if( !m_currentConnection )
         return;
-    QString text = m_chatEdit->displayText();
+    QString text = m_chatEdit->input();
     if ( text.isEmpty() )
         return;
 
@@ -234,7 +214,7 @@ void ChatRoomWidget::sendLine()
             } else
                 m_currentRoom->postMessage("m.text", text);
         }
-    m_chatEdit->setText("");
+    m_chatEdit->clear();
 }
 
 void ChatRoomWidget::findCompletionMatches(const QString& pattern)
@@ -270,12 +250,12 @@ void ChatRoomWidget::triggerCompletion()
     }
     if ( m_completing )
     {
-        QString inputText = m_chatEdit->text();
+        const QString inputText = m_chatEdit->toPlainText();
         m_chatEdit->setText( inputText.left(m_completionInsertStart)
             + m_completionList.at(m_completionListPosition)
             + inputText.right(inputText.length() - m_completionInsertStart - m_completionLength) );
         m_completionLength = m_completionList.at(m_completionListPosition).length();
-        m_chatEdit->setCursorPosition( m_completionInsertStart + m_completionLength + m_completionCursorOffset );
+        m_chatEdit->textCursor().setPosition( m_completionInsertStart + m_completionLength + m_completionCursorOffset );
         m_completionListPosition = (m_completionListPosition + 1) % m_completionList.length();
         m_currentlyTyping->setText( QString("<i>Tab Completion (next: %1)</i>").arg(
             QStringList(m_completionList.mid( m_completionListPosition, 5)).join(", ") ) );
@@ -284,8 +264,8 @@ void ChatRoomWidget::triggerCompletion()
 
 void ChatRoomWidget::startNewCompletion()
 {
-    QString inputText = m_chatEdit->text();
-    int cursorPosition = m_chatEdit->cursorPosition();
+    const QString inputText = m_chatEdit->toPlainText();
+    const int cursorPosition = m_chatEdit->textCursor().position();
     for ( m_completionInsertStart = cursorPosition; --m_completionInsertStart >= 0; )
     {
         if ( !(inputText.at(m_completionInsertStart).isLetterOrNumber() || inputText.at(m_completionInsertStart) == '@') )
@@ -414,6 +394,21 @@ void ChatRoomWidget::markShownAsRead()
         Q_ASSERT( iter != m_currentRoom->timelineEdge() );
         m_currentRoom->markMessagesAsRead((*iter)->id());
     }
+}
+
+bool ChatRoomWidget::eventFilter(QObject *object, QEvent *event)
+{
+    if (object != m_chatEdit || event->type() != QEvent::KeyPress)
+        return QWidget::eventFilter(object, event);
+
+    auto keyEvent = static_cast<QKeyEvent*>(event);
+    if (keyEvent->key() == Qt::Key_Tab) {
+        emit triggerCompletion();
+        return true;
+    }
+
+    emit cancelCompletion();
+    return false;
 }
 
 bool ChatRoomWidget::pendingMarkRead() const

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -41,15 +41,15 @@
 class ChatEdit : public KChatEdit
 {
 public:
-    ChatEdit(ChatRoomWidget* c, QWidget* parent = nullptr);
+    ChatEdit(ChatRoomWidget* c);
 protected:
     void keyPressEvent(QKeyEvent* event) override;
 private:
     ChatRoomWidget* m_chatRoomWidget;
 };
 
-ChatEdit::ChatEdit(ChatRoomWidget* c, QWidget* parent)
-    : KChatEdit(parent)
+ChatEdit::ChatEdit(ChatRoomWidget* c)
+    : KChatEdit(c)
     , m_chatRoomWidget(c) {};
 
 void ChatEdit::keyPressEvent(QKeyEvent* event)

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -24,9 +24,9 @@
 
 #include "quaternionroom.h"
 
+class ChatEdit;
 class MessageEventModel;
 class ImageProvider;
-class KChatEdit;
 class QFrame;
 class QQuickView;
 class QListView;
@@ -40,7 +40,6 @@ class ChatRoomWidget: public QWidget
         ChatRoomWidget(QWidget* parent = nullptr);
         virtual ~ChatRoomWidget();
 
-        bool eventFilter(QObject* object, QEvent* event) override;
         void enableDebug();
         void triggerCompletion();
         void cancelCompletion();
@@ -83,7 +82,7 @@ class ChatRoomWidget: public QWidget
         //QListView* m_messageView;
         QQuickView* m_quickView;
         ImageProvider* m_imageProvider;
-        KChatEdit* m_chatEdit;
+        ChatEdit* m_chatEdit;
         QLabel* m_currentlyTyping;
         QLabel* m_topicLabel;
 

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -26,6 +26,7 @@
 
 class MessageEventModel;
 class ImageProvider;
+class KChatEdit;
 class QFrame;
 class QQuickView;
 class QListView;
@@ -39,6 +40,7 @@ class ChatRoomWidget: public QWidget
         ChatRoomWidget(QWidget* parent = nullptr);
         virtual ~ChatRoomWidget();
 
+        bool eventFilter(QObject* object, QEvent* event) override;
         void enableDebug();
         void triggerCompletion();
         void cancelCompletion();
@@ -81,7 +83,7 @@ class ChatRoomWidget: public QWidget
         //QListView* m_messageView;
         QQuickView* m_quickView;
         ImageProvider* m_imageProvider;
-        QLineEdit* m_chatEdit;
+        KChatEdit* m_chatEdit;
         QLabel* m_currentlyTyping;
         QLabel* m_topicLabel;
 
@@ -90,6 +92,7 @@ class ChatRoomWidget: public QWidget
         timeline_index_t indexToMaybeRead;
         QBasicTimer maybeReadTimer;
         bool readMarkerOnScreen;
+        QMap<QuaternionRoom*, QStringList> roomHistories;
 
         void reStartShownTimer();
 };

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2017 Elvis Angelaccio <elvis.angelaccio@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "kchatedit.h"
+
+#include <QDebug>
+#include <QGuiApplication>
+#include <QKeyEvent>
+
+class KChatEdit::KChatEditPrivate
+{
+public:
+    KChatEditPrivate(KChatEdit *parent)
+        : q(parent)
+        , index(0)
+        , maxHistorySize(100)
+    {}
+
+    void init();
+    void rewindHistory();
+    void forwardHistory();
+    void saveInput();
+
+    KChatEdit *q;
+    QStringList history;
+    int index;
+    int maxHistorySize;
+};
+
+void KChatEdit::KChatEditPrivate::init()
+{
+    // History always ends with a dummy placeholder string.
+    history << QString();
+}
+
+void KChatEdit::KChatEditPrivate::rewindHistory()
+{
+    history[index] = q->acceptRichText() ? q->toHtml() : q->toPlainText();
+
+    // History finished, nothing to do.
+    if (index == 0) {
+        return;
+    }
+
+    index--;
+    q->setText(history.at(index));
+    q->moveCursor(QTextCursor::End);
+}
+
+void KChatEdit::KChatEditPrivate::forwardHistory()
+{
+    history[index] = q->acceptRichText() ? q->toHtml() : q->toPlainText();
+
+    // Back from history, nothing to do.
+    if (index == history.size() - 1) {
+        return;
+    }
+
+    index++;
+    q->setText(history.at(index));
+    q->moveCursor(QTextCursor::End);
+}
+
+void KChatEdit::KChatEditPrivate::saveInput()
+{
+    const QString input = q->acceptRichText() ? q->toHtml() : q->toPlainText();
+    if (input.isEmpty()) {
+        return;
+    }
+
+    // Only save input if different from the latest one.
+    if (input != q->input()) {
+        // Replace empty placeholder with the new input.
+        history[history.size() - 1] = input;
+        history << QString();
+
+        if(history.size() > maxHistorySize) {
+            history.removeFirst();
+        }
+    }
+
+    index = history.size() - 1;
+
+    q->clear();
+    emit q->inputChanged(input);
+}
+
+KChatEdit::KChatEdit(QWidget *parent)
+    : QTextEdit(parent), d(new KChatEditPrivate(this))
+{
+    d->init();
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
+    connect(this, &QTextEdit::textChanged, this, &QWidget::updateGeometry);
+}
+
+KChatEdit::~KChatEdit()
+{
+}
+
+QString KChatEdit::input() const
+{
+    return d->history.value(d->history.size() - 2);
+}
+
+QStringList KChatEdit::history() const
+{
+    return d->history;
+}
+
+void KChatEdit::setHistory(const QStringList &history)
+{
+    d->history = history;
+    if (!history.endsWith(QString())) {
+        d->history << QString();
+    }
+
+    while (d->history.size() > maxHistorySize()) {
+        d->history.removeFirst();
+    }
+
+    d->index = d->history.size() - 1;
+}
+
+int KChatEdit::maxHistorySize() const
+{
+    return d->maxHistorySize;
+}
+
+void KChatEdit::setMaxHistorySize(int maxHistorySize)
+{
+    d->maxHistorySize = maxHistorySize;
+}
+
+QSize KChatEdit::minimumSizeHint() const
+{
+    QSize minimumSizeHint = QTextEdit::minimumSizeHint();
+    QMargins margins = viewportMargins();
+    margins += static_cast<int>(document()->documentMargin());
+    margins += contentsMargins();
+
+    if (!placeholderText().isEmpty()) {
+        minimumSizeHint.setWidth(fontMetrics().width(placeholderText()) + margins.left()*2.5);
+    }
+    minimumSizeHint.setHeight(fontMetrics().lineSpacing() + margins.top() + margins.bottom());
+
+    return minimumSizeHint;
+}
+
+QSize KChatEdit::sizeHint() const
+{
+    ensurePolished();
+
+    if (document()->isEmpty()) {
+        return minimumSizeHint();
+    }
+
+    QMargins margins = viewportMargins();
+    margins += static_cast<int>(document()->documentMargin());
+    margins += contentsMargins();
+
+    QSize size = document()->size().toSize();
+    size.rwidth() += margins.left() + margins.right();
+    size.rheight() += margins.top() + margins.bottom();
+
+    // Be consistent with minimumSizeHint().
+    if (document()->lineCount() == 1 && !toPlainText().contains(QLatin1Char('\n'))) {
+        size.setHeight(fontMetrics().lineSpacing() + margins.top() + margins.bottom());
+    }
+
+    return size;
+}
+
+void KChatEdit::keyPressEvent(QKeyEvent *event)
+{
+    switch (event->key()) {
+    case Qt::Key_Enter:
+    case Qt::Key_Return:
+        if (!(QGuiApplication::keyboardModifiers() & Qt::ShiftModifier)) {
+            d->saveInput();
+            return;
+        }
+        break;
+    case Qt::Key_Up:
+        if (!textCursor().movePosition(QTextCursor::Up)) {
+            d->rewindHistory();
+        }
+        break;
+    case Qt::Key_Down:
+        if (!document()->isEmpty() && !textCursor().movePosition(QTextCursor::Down)) {
+            d->forwardHistory();
+        }
+        break;
+    default:
+        break;
+    }
+
+    QTextEdit::keyPressEvent(event);
+}
+

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -148,7 +148,7 @@ void KChatEdit::setMaxHistorySize(int maxHistorySize)
 QSize KChatEdit::minimumSizeHint() const
 {
     QSize minimumSizeHint = QTextEdit::minimumSizeHint();
-    QMargins margins = viewportMargins();
+    QMargins margins;
     margins += static_cast<int>(document()->documentMargin());
     margins += contentsMargins();
 
@@ -168,7 +168,7 @@ QSize KChatEdit::sizeHint() const
         return minimumSizeHint();
     }
 
-    QMargins margins = viewportMargins();
+    QMargins margins;
     margins += static_cast<int>(document()->documentMargin());
     margins += contentsMargins();
 

--- a/client/kchatedit.h
+++ b/client/kchatedit.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2017 Elvis Angelaccio <elvis.angelaccio@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KCHATEDIT_H
+#define KCHATEDIT_H
+
+#include <QTextEdit>
+
+/**
+ * @class KChatEdit kchatedit.h KChatEdit
+ *
+ * @brief An input widget with history for chat applications.
+ *
+ * This widget can be used to get input for chat windows, which tipically corresponds to chat messages or
+ * protocol-specific commands (for example the "/whois" IRC command).
+ *
+ * By default the widget takes as less space as possible, which is the same space as used by a QLineEdit.
+ * It is possible to expand the widget and enter "multi-line" messages, by pressing Shift + Return.
+ *
+ * Chat applications usually maintain a history of what the user typed, which can be browsed with the
+ * Up and Down keys (exactly like in command-line shells). This feature is fully supported by this widget.
+ * Pressing the Return key makes the input text disappear, as typical in chat applications. The input goes
+ * in the history and can be retrieved with the input() method.
+ *
+ * @author Elvis Angelaccio <elvis.angelaccio@kde.org>
+ */
+class KChatEdit : public QTextEdit
+{
+    Q_OBJECT
+    Q_PROPERTY(QString input READ input NOTIFY inputChanged)
+    Q_PROPERTY(QStringList history READ history WRITE setHistory)
+    Q_PROPERTY(int maxHistorySize READ maxHistorySize WRITE setMaxHistorySize)
+
+public:
+    explicit KChatEdit(QWidget *parent = nullptr);
+    virtual ~KChatEdit();
+
+    /**
+     * The latest input text that the user provided by pressing the Return key.
+     * This corresponds to the last element of history().
+     * @return Latest available input or an empty string if nothing has been typed yet.
+     * @note If the history is full (see maxHistorySize(), new inputs will take space from the oldest
+     * items in the history.
+     * @see history(), maxHistorySize(), inputChanged()
+     */
+    QString input() const;
+
+    /**
+     * @return The history of the text inputs that the user typed.
+     * @see input()
+     */
+    QStringList history() const;
+
+    /**
+     * Set the history of this widget to @p history.
+     * This can be useful when sharing a single instance of KChatEdit with many "channels" or "rooms"
+     * that maintain their own private history.
+     */
+    void setHistory(const QStringList &history);
+
+    /**
+     * @return The maximum number of input items that the history can store.
+     * @see history()
+     */
+    int maxHistorySize() const;
+
+    /**
+     * Set the maximum number of input items that the history can store.
+     * @see maxHistorySize()
+     */
+    void setMaxHistorySize(int maxHistorySize);
+
+    QSize minimumSizeHint() const Q_DECL_OVERRIDE;
+    QSize sizeHint() const Q_DECL_OVERRIDE;
+
+Q_SIGNALS:
+    /**
+     * The user has typed @p input and then pressed the Return key.
+     * @see input()
+     */
+    void inputChanged(const QString &input);
+
+protected:
+    void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
+
+private:
+    class KChatEditPrivate;
+    QScopedPointer<KChatEditPrivate> d;
+
+    Q_DISABLE_COPY(KChatEdit)
+};
+
+#endif


### PR DESCRIPTION
Use KChatEdit rather than a custom QLineEdit. KChatEdit is designed as
general-purpose input widget for chat applications, not Matrix-specific.
It has built-in support for history. Tab completion is achieved by
installing a simple event filter.

Rich-text is disabled, for now. We need support for it in the backend
library first.