### PR TITLE
Port to KChatEdit::saveInput()

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -93,7 +93,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     m_chatEdit = new ChatEdit(this);
     m_chatEdit->setPlaceholderText(tr("Send a message (unencrypted)..."));
     m_chatEdit->setAcceptRichText(false);
-    connect( m_chatEdit, &KChatEdit::inputChanged, this, &ChatRoomWidget::sendLine );
+    connect( m_chatEdit, &KChatEdit::inputChanged, this, &ChatRoomWidget::sendInput );
 
     m_currentlyTyping = new QLabel();
     auto topicSeparator = new QFrame();
@@ -201,12 +201,12 @@ void ChatRoomWidget::topicChanged()
     m_topicLabel->setText( m_currentRoom->prettyTopic() );
 }
 
-void ChatRoomWidget::sendLine()
+void ChatRoomWidget::sendInput(const QString& input)
 {
-    qDebug() << "sendLine";
+    qDebug() << "Got input:" << input;
     if( !m_currentConnection )
         return;
-    QString text = m_chatEdit->input();
+    QString text = input;
     if ( text.isEmpty() )
         return;
 
@@ -240,7 +240,7 @@ void ChatRoomWidget::sendLine()
             } else
                 m_currentRoom->postMessage("m.text", text);
         }
-    m_chatEdit->clear();
+    m_chatEdit->saveInput();
 }
 
 void ChatRoomWidget::findCompletionMatches(const QString& pattern)

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -206,7 +206,7 @@ void ChatRoomWidget::sendInput(const QString& input)
     qDebug() << "Got input:" << input;
     if( !m_currentConnection )
         return;
-    QString text = input;
+    QString text = m_chatEdit->document()->toPlainText();
     if ( text.isEmpty() )
         return;
 

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -63,7 +63,7 @@ class ChatRoomWidget: public QWidget
         void timerEvent(QTimerEvent* event) override;
 
     private slots:
-        void sendLine();
+        void sendInput(const QString& input);
 
     private:
         MessageEventModel* m_messageModel;

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -31,6 +31,7 @@ public:
     {}
 
     void init();
+    void emitInputChanged();
     void rewindHistory();
     void forwardHistory();
     void saveInput();
@@ -45,6 +46,16 @@ void KChatEdit::KChatEditPrivate::init()
 {
     // History always ends with a dummy placeholder string.
     history << QString();
+}
+
+void KChatEdit::KChatEditPrivate::emitInputChanged()
+{
+    const QString input = q->acceptRichText() ? q->toHtml() : q->toPlainText();
+    if (input.isEmpty()) {
+        return;
+    }
+
+    emit q->inputChanged(input);
 }
 
 void KChatEdit::KChatEditPrivate::rewindHistory()
@@ -94,9 +105,7 @@ void KChatEdit::KChatEditPrivate::saveInput()
     }
 
     index = history.size() - 1;
-
     q->clear();
-    emit q->inputChanged(input);
 }
 
 KChatEdit::KChatEdit(QWidget *parent)
@@ -114,6 +123,11 @@ KChatEdit::~KChatEdit()
 QString KChatEdit::input() const
 {
     return d->history.value(d->history.size() - 2);
+}
+
+void KChatEdit::saveInput()
+{
+    d->saveInput();
 }
 
 QStringList KChatEdit::history() const
@@ -190,7 +204,7 @@ void KChatEdit::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Enter:
     case Qt::Key_Return:
         if (!(QGuiApplication::keyboardModifiers() & Qt::ShiftModifier)) {
-            d->saveInput();
+            d->emitInputChanged();
             return;
         }
         break;

--- a/client/kchatedit.h
+++ b/client/kchatedit.h
@@ -33,8 +33,9 @@
  *
  * Chat applications usually maintain a history of what the user typed, which can be browsed with the
  * Up and Down keys (exactly like in command-line shells). This feature is fully supported by this widget.
- * Pressing the Return key makes the input text disappear, as typical in chat applications. The input goes
- * in the history and can be retrieved with the input() method.
+ * The widget emits the inputChanged() signal upon pressing the Return key.
+ * You can then call saveInput() to make the input text disappear, as typical in chat applications.
+ * The input goes in the history and can be retrieved with the input() method.
  *
  * @author Elvis Angelaccio <elvis.angelaccio@kde.org>
  */
@@ -50,18 +51,25 @@ public:
     virtual ~KChatEdit();
 
     /**
-     * The latest input text that the user provided by pressing the Return key.
+     * The latest input text typed by the user.
      * This corresponds to the last element of history().
-     * @return Latest available input or an empty string if nothing has been typed yet.
-     * @note If the history is full (see maxHistorySize(), new inputs will take space from the oldest
-     * items in the history.
-     * @see history(), maxHistorySize(), inputChanged()
+     * @return Latest available input or an empty string if saveInput() has not been called yet.
+     * @see inputChanged(), saveInput(), history()
      */
     QString input() const;
 
     /**
+     * Saves in the history the text typed before pressing the Return key.
+     * This also clears the QTextEdit area.
+     * @note If the history is full (see maxHistorySize(), new inputs will take space from the oldest
+     * items in the history.
+     * @see input(), history(), maxHistorySize()
+     */
+    void saveInput();
+
+    /**
      * @return The history of the text inputs that the user typed.
-     * @see input()
+     * @see input(), saveInput();
      */
     QStringList history() const;
 
@@ -90,7 +98,8 @@ public:
 Q_SIGNALS:
     /**
      * The user has typed @p input and then pressed the Return key.
-     * @see input()
+     * Call saveInput() if you want to push @p input to the history.
+     * @see input(), saveInput(), history()
      */
     void inputChanged(const QString &input);
 


### PR DESCRIPTION
Pressing Return now only emits the inputChanged() signal, but neither
clears the text edit nor saves the input in the history.
The new saveInput() method explicitly takes care of these tasks.

See issue #142.