### PR TITLE
Improve chatedit widget

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -93,7 +93,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     m_chatEdit = new ChatEdit(this);
     m_chatEdit->setPlaceholderText(tr("Send a message (unencrypted)..."));
     m_chatEdit->setAcceptRichText(false);
-    connect( m_chatEdit, &KChatEdit::inputChanged, this, &ChatRoomWidget::sendLine );
+    connect( m_chatEdit, &KChatEdit::returnPressed, this, &ChatRoomWidget::sendInput );
 
     m_currentlyTyping = new QLabel();
     auto topicSeparator = new QFrame();
@@ -203,12 +203,12 @@ void ChatRoomWidget::topicChanged()
     m_topicLabel->setText( m_currentRoom->prettyTopic() );
 }
 
-void ChatRoomWidget::sendLine()
+void ChatRoomWidget::sendInput()
 {
     qDebug() << "sendLine";
     if( !m_currentConnection )
         return;
-    QString text = m_chatEdit->input();
+    QString text = m_chatEdit->toPlainText();
     if ( text.isEmpty() )
         return;
 
@@ -242,7 +242,7 @@ void ChatRoomWidget::sendLine()
             } else
                 m_currentRoom->postMessage("m.text", text);
         }
-    m_chatEdit->clear();
+    m_chatEdit->saveInput();
 }
 
 void ChatRoomWidget::findCompletionMatches(const QString& pattern)

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -32,6 +32,7 @@ class QQuickView;
 class QListView;
 class QLineEdit;
 class QLabel;
+class QTextDocument;
 
 class ChatRoomWidget: public QWidget
 {
@@ -63,7 +64,7 @@ class ChatRoomWidget: public QWidget
         void timerEvent(QTimerEvent* event) override;
 
     private slots:
-        void sendLine();
+        void sendInput();
 
     private:
         MessageEventModel* m_messageModel;
@@ -91,7 +92,7 @@ class ChatRoomWidget: public QWidget
         timeline_index_t indexToMaybeRead;
         QBasicTimer maybeReadTimer;
         bool readMarkerOnScreen;
-        QMap<QuaternionRoom*, QStringList> roomHistories;
+        QMap<QuaternionRoom*, QList<QTextDocument*>> roomHistories;
 
         void reStartShownTimer();
 };

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -92,7 +92,7 @@ class ChatRoomWidget: public QWidget
         timeline_index_t indexToMaybeRead;
         QBasicTimer maybeReadTimer;
         bool readMarkerOnScreen;
-        QMap<QuaternionRoom*, QList<QTextDocument*>> roomHistories;
+        QMap<QuaternionRoom*, QVector<QTextDocument*>> roomHistories;
 
         void reStartShownTimer();
 };

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -37,7 +37,7 @@ public:
     void saveInput();
 
     KChatEdit *q;
-    QList<QTextDocument*> history;
+    QVector<QTextDocument*> history;
     int index;
     int maxHistorySize;
 };
@@ -92,7 +92,7 @@ void KChatEdit::KChatEditPrivate::saveInput()
     }
 
     const QString input = q->acceptRichText() ? q->toHtml() : q->toPlainText();
-    const QString latestInput = q->acceptRichText() ? q->input()->toHtml() : q->input()->toPlainText();
+    const QString latestInput = q->acceptRichText() ? q->savedInput()->toHtml() : q->savedInput()->toPlainText();
     // Only save input if different from the latest one.
     if (input != latestInput) {
         // Replace empty placeholder with the new input.
@@ -105,7 +105,7 @@ void KChatEdit::KChatEditPrivate::saveInput()
     }
 
     index = history.size() - 1;
-    emit q->inputChanged();
+    emit q->savedInputChanged();
     q->clear();
 }
 
@@ -121,7 +121,7 @@ KChatEdit::~KChatEdit()
 {
 }
 
-QTextDocument* KChatEdit::input() const
+QTextDocument* KChatEdit::savedInput() const
 {
     if (d->history.size() >= 2)
         return d->history.at(d->history.size() - 2);
@@ -135,12 +135,12 @@ void KChatEdit::saveInput()
     d->saveInput();
 }
 
-QList<QTextDocument*> KChatEdit::history() const
+QVector<QTextDocument*> KChatEdit::history() const
 {
     return d->history;
 }
 
-void KChatEdit::setHistory(const QList<QTextDocument*> &history)
+void KChatEdit::setHistory(const QVector<QTextDocument*> &history)
 {
     d->history = history;
     if (history.isEmpty() || !history.last()->isEmpty()) {

--- a/client/kchatedit.cpp
+++ b/client/kchatedit.cpp
@@ -174,7 +174,11 @@ QSize KChatEdit::minimumSizeHint() const
     if (!placeholderText().isEmpty()) {
         minimumSizeHint.setWidth(fontMetrics().width(placeholderText()) + margins.left()*2.5);
     }
-    minimumSizeHint.setHeight(fontMetrics().lineSpacing() + margins.top() + margins.bottom());
+    if (document()->isEmpty()) {
+        minimumSizeHint.setHeight(fontMetrics().lineSpacing() + margins.top() + margins.bottom());
+    } else {
+        minimumSizeHint.setHeight(document()->size().height());
+    }
 
     return minimumSizeHint;
 }

--- a/client/kchatedit.h
+++ b/client/kchatedit.h
@@ -33,16 +33,17 @@
  *
  * Chat applications usually maintain a history of what the user typed, which can be browsed with the
  * Up and Down keys (exactly like in command-line shells). This feature is fully supported by this widget.
- * Pressing the Return key makes the input text disappear, as typical in chat applications. The input goes
- * in the history and can be retrieved with the input() method.
+ * The widget emits the inputRequested() signal upon pressing the Return key.
+ * You can then call saveInput() to make the input text disappear, as typical in chat applications.
+ * The input goes in the history and can be retrieved with the input() method.
  *
  * @author Elvis Angelaccio <elvis.angelaccio@kde.org>
  */
 class KChatEdit : public QTextEdit
 {
     Q_OBJECT
-    Q_PROPERTY(QString input READ input NOTIFY inputChanged)
-    Q_PROPERTY(QStringList history READ history WRITE setHistory)
+    Q_PROPERTY(QTextDocument* input READ input NOTIFY inputChanged)
+    Q_PROPERTY(QList<QTextDocument*> history READ history WRITE setHistory)
     Q_PROPERTY(int maxHistorySize READ maxHistorySize WRITE setMaxHistorySize)
 
 public:
@@ -50,27 +51,34 @@ public:
     virtual ~KChatEdit();
 
     /**
-     * The latest input text that the user provided by pressing the Return key.
+     * The latest input text typed by the user.
      * This corresponds to the last element of history().
-     * @return Latest available input or an empty string if nothing has been typed yet.
+     * @return Latest available input or an empty document if saveInput() has not been called yet.
+     * @see inputChanged(), saveInput(), history()
+     */
+    QTextDocument* input() const;
+
+    /**
+     * Saves in the history the current document().
+     * This also clears the QTextEdit area.
      * @note If the history is full (see maxHistorySize(), new inputs will take space from the oldest
      * items in the history.
-     * @see history(), maxHistorySize(), inputChanged()
+     * @see input(), history(), maxHistorySize()
      */
-    QString input() const;
+    void saveInput();
 
     /**
      * @return The history of the text inputs that the user typed.
-     * @see input()
+     * @see input(), saveInput();
      */
-    QStringList history() const;
+    QList<QTextDocument*> history() const;
 
     /**
      * Set the history of this widget to @p history.
      * This can be useful when sharing a single instance of KChatEdit with many "channels" or "rooms"
      * that maintain their own private history.
      */
-    void setHistory(const QStringList &history);
+    void setHistory(const QList<QTextDocument*> &history);
 
     /**
      * @return The maximum number of input items that the history can store.
@@ -89,10 +97,17 @@ public:
 
 Q_SIGNALS:
     /**
-     * The user has typed @p input and then pressed the Return key.
-     * @see input()
+     * A new input has been saved in the history.
+     * @see input(), saveInput(), history()
      */
-    void inputChanged(const QString &input);
+    void inputChanged();
+
+    /**
+     * Emitted when the user types Key_Return or Key_Enter, which typically means the user
+     * wants to "send" what was typed. Call saveInput() if you want to actually save the input.
+     * @see input(), saveInput(), history()
+     */
+    void returnPressed();
 
 protected:
     void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;

--- a/client/kchatedit.h
+++ b/client/kchatedit.h
@@ -35,15 +35,15 @@
  * Up and Down keys (exactly like in command-line shells). This feature is fully supported by this widget.
  * The widget emits the inputRequested() signal upon pressing the Return key.
  * You can then call saveInput() to make the input text disappear, as typical in chat applications.
- * The input goes in the history and can be retrieved with the input() method.
+ * The input goes in the history and can be retrieved with the savedInput() method.
  *
  * @author Elvis Angelaccio <elvis.angelaccio@kde.org>
  */
 class KChatEdit : public QTextEdit
 {
     Q_OBJECT
-    Q_PROPERTY(QTextDocument* input READ input NOTIFY inputChanged)
-    Q_PROPERTY(QList<QTextDocument*> history READ history WRITE setHistory)
+    Q_PROPERTY(QTextDocument* savedInput READ savedInput NOTIFY savedInputChanged)
+    Q_PROPERTY(QVector<QTextDocument*> history READ history WRITE setHistory)
     Q_PROPERTY(int maxHistorySize READ maxHistorySize WRITE setMaxHistorySize)
 
 public:
@@ -51,34 +51,34 @@ public:
     virtual ~KChatEdit();
 
     /**
-     * The latest input text typed by the user.
+     * The latest input text saved in the history.
      * This corresponds to the last element of history().
      * @return Latest available input or an empty document if saveInput() has not been called yet.
      * @see inputChanged(), saveInput(), history()
      */
-    QTextDocument* input() const;
+    QTextDocument* savedInput() const;
 
     /**
      * Saves in the history the current document().
      * This also clears the QTextEdit area.
      * @note If the history is full (see maxHistorySize(), new inputs will take space from the oldest
      * items in the history.
-     * @see input(), history(), maxHistorySize()
+     * @see savedInput(), history(), maxHistorySize()
      */
     void saveInput();
 
     /**
      * @return The history of the text inputs that the user typed.
-     * @see input(), saveInput();
+     * @see savedInput(), saveInput();
      */
-    QList<QTextDocument*> history() const;
+    QVector<QTextDocument*> history() const;
 
     /**
      * Set the history of this widget to @p history.
      * This can be useful when sharing a single instance of KChatEdit with many "channels" or "rooms"
      * that maintain their own private history.
      */
-    void setHistory(const QList<QTextDocument*> &history);
+    void setHistory(const QVector<QTextDocument*> &history);
 
     /**
      * @return The maximum number of input items that the history can store.
@@ -98,14 +98,14 @@ public:
 Q_SIGNALS:
     /**
      * A new input has been saved in the history.
-     * @see input(), saveInput(), history()
+     * @see savedInput(), saveInput(), history()
      */
-    void inputChanged();
+    void savedInputChanged();
 
     /**
      * Emitted when the user types Key_Return or Key_Enter, which typically means the user
      * wants to "send" what was typed. Call saveInput() if you want to actually save the input.
-     * @see input(), saveInput(), history()
+     * @see savedInput(), saveInput(), history()
      */
     void returnPressed();
 


### PR DESCRIPTION
Previously the chat edit widget provided only QString objects, containing
either plain text or html. Now the api is much more flexible, as the caller
can choose what to do with the QTextDocument.

Another change in behavior is that pressing Return no longer clears the
input and puts it in the history. A returnPressed() signal notifies when
Return is pressed, and a new saveInput() method can be used to
explicitly accept an input and store it in the history.

Fixes #142