### PR TITLE
Don't lose focus when clicking a room twice

### DIFF
--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -127,8 +127,10 @@ void ChatRoomWidget::enableDebug()
 
 void ChatRoomWidget::setRoom(QuaternionRoom* room)
 {
-    if (m_currentRoom == room)
+    if (m_currentRoom == room) {
+        m_chatEdit->setFocus();
         return;
+    }
 
     readMarkerOnScreen = false;
     maybeReadTimer.stop();


### PR DESCRIPTION
Without this setFocus() call, the focus would go to the room view
widget.