### PR TITLE
Chat edit refactored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(quaternion_SRCS
     client/roomlistdock.cpp
     client/userlistdock.cpp
     client/kchatedit.cpp
+    client/chatedit.cpp
     client/chatroomwidget.cpp
     client/systemtray.cpp
     client/models/messageeventmodel.cpp

--- a/client/chatedit.cpp
+++ b/client/chatedit.cpp
@@ -1,0 +1,103 @@
+/**************************************************************************
+ *                                                                        *
+ * Copyright (C) 2017 Kitsune Ral <kitsune-ral@users.sf.net>
+ *                                                                        *
+ * This program is free software; you can redistribute it and/or          *
+ * modify it under the terms of the GNU General Public License            *
+ * as published by the Free Software Foundation; either version 3         *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * This program is distributed in the hope that it will be useful,        *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ * GNU General Public License for more details.                           *
+ *                                                                        *
+ * You should have received a copy of the GNU General Public License      *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                        *
+ **************************************************************************/
+
+#include "chatedit.h"
+
+#include <QtGui/QKeyEvent>
+
+#include "chatroomwidget.h"
+
+ChatEdit::ChatEdit(ChatRoomWidget* c) : KChatEdit(c), chatRoomWidget(c) { }
+
+void ChatEdit::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Tab) {
+        triggerCompletion();
+        return;
+    }
+
+    cancelCompletion();
+    KChatEdit::keyPressEvent(event);
+}
+
+void ChatEdit::startNewCompletion()
+{
+    const QString inputText = toPlainText();
+    const int cursorPosition = textCursor().position();
+    for ( m_completionInsertStart = cursorPosition; --m_completionInsertStart >= 0; )
+    {
+        if ( !(inputText.at(m_completionInsertStart).isLetterOrNumber() || inputText.at(m_completionInsertStart) == '@') )
+            break;
+    }
+    ++m_completionInsertStart;
+    m_completionLength = cursorPosition - m_completionInsertStart;
+    m_completionList = chatRoomWidget->findCompletionMatches(inputText.mid(m_completionInsertStart, m_completionLength));
+    if ( !m_completionList.isEmpty() )
+    {
+        m_completionCursorOffset = 0;
+        m_completionListPosition = 0;
+        m_completionLength = 0;
+        if ( m_completionInsertStart == 0)
+        {
+            setText(inputText.left(m_completionInsertStart) + ": " + inputText.mid(cursorPosition));
+            m_completionCursorOffset = 2;
+        }
+        else if ( inputText.mid(m_completionInsertStart - 2, 2) == ": ")
+        {
+            setText(inputText.left(m_completionInsertStart - 2) + ", : " + inputText.mid(cursorPosition));
+            m_completionCursorOffset = 2;
+        }
+        else if ( inputText.mid(m_completionInsertStart - 1, 1) == ":")
+        {
+            setText(inputText.left(m_completionInsertStart - 1) + ", : " + inputText.mid(cursorPosition));
+            ++m_completionInsertStart;
+            m_completionCursorOffset = 2;
+        }
+        else
+        {
+            setText(inputText.left(m_completionInsertStart) + " " + inputText.mid(cursorPosition));
+            m_completionCursorOffset = 1;
+        }
+    }
+}
+
+void ChatEdit::triggerCompletion()
+{
+    if (m_completionList.isEmpty())
+    {
+        startNewCompletion();
+    }
+    if (!m_completionList.isEmpty())
+    {
+        const QString inputText = toPlainText();
+        setText( inputText.left(m_completionInsertStart)
+                             + m_completionList.at(m_completionListPosition)
+                             + inputText.right(inputText.length() - m_completionInsertStart - m_completionLength) );
+        m_completionLength = m_completionList.at(m_completionListPosition).length();
+        textCursor().setPosition( m_completionInsertStart + m_completionLength + m_completionCursorOffset );
+        m_completionListPosition = (m_completionListPosition + 1) % m_completionList.length();
+        emit proposedCompletion(m_completionList, m_completionListPosition);
+    }
+}
+
+void ChatEdit::cancelCompletion()
+{
+    m_completionList.clear();
+    emit cancelledCompletion();
+}

--- a/client/chatedit.h
+++ b/client/chatedit.h
@@ -21,6 +21,8 @@
 
 #include "kchatedit.h"
 
+#include <QtGui/QTextCursor>
+
 class ChatRoomWidget;
 
 class ChatEdit : public KChatEdit
@@ -42,13 +44,12 @@ class ChatEdit : public KChatEdit
     private:
         ChatRoomWidget* chatRoomWidget;
 
-        QStringList m_completionList;
-        int m_completionListPosition;
-        int m_completionInsertStart;
-        int m_completionLength;
-        int m_completionCursorOffset;
+        QTextCursor completionCursor;
+        QStringList completionMatches;
+        int matchesListPosition;
 
         void startNewCompletion();
+        void appendTextAtCursor(const QString& text, bool select = false);
 };
 
 

--- a/client/chatedit.h
+++ b/client/chatedit.h
@@ -1,0 +1,54 @@
+/**************************************************************************
+ *                                                                        *
+ * Copyright (C) 2017 Kitsune Ral <kitsune-ral@users.sf.net>
+ *                                                                        *
+ * This program is free software; you can redistribute it and/or          *
+ * modify it under the terms of the GNU General Public License            *
+ * as published by the Free Software Foundation; either version 3         *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * This program is distributed in the hope that it will be useful,        *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ * GNU General Public License for more details.                           *
+ *                                                                        *
+ * You should have received a copy of the GNU General Public License      *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                        *
+ **************************************************************************/
+
+#pragma once
+
+#include "kchatedit.h"
+
+class ChatRoomWidget;
+
+class ChatEdit : public KChatEdit
+{
+        Q_OBJECT
+    public:
+        ChatEdit(ChatRoomWidget* c);
+
+        void triggerCompletion();
+        void cancelCompletion();
+
+    signals:
+        void proposedCompletion(const QStringList& allCompletions, int curIndex);
+        void cancelledCompletion();
+
+    protected:
+        void keyPressEvent(QKeyEvent* event) override;
+
+    private:
+        ChatRoomWidget* chatRoomWidget;
+
+        QStringList m_completionList;
+        int m_completionListPosition;
+        int m_completionInsertStart;
+        int m_completionLength;
+        int m_completionCursorOffset;
+
+        void startNewCompletion();
+};
+
+

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -78,7 +78,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
             [=](const QStringList& matches, int pos)
             {
                 m_currentlyTyping->setText(
-                    QStringLiteral("<i>Tab Completion (next: %1)</i>")
+                    tr("<i>Tab Completion (next: %1)</i>")
                     .arg( QStringList(matches.mid(pos, 5)).join(", ") ) );
             });
     connect(m_chatEdit, &ChatEdit::cancelledCompletion,
@@ -168,7 +168,7 @@ void ChatRoomWidget::typingChanged()
     {
         typingNames << m_currentRoom->roomMembername(user);
     }
-    m_currentlyTyping->setText(QStringLiteral("<i>Currently typing: %1</i>")
+    m_currentlyTyping->setText(tr("<i>Currently typing: %1</i>")
                                .arg( typingNames.join(", ") ) );
 }
 
@@ -177,7 +177,7 @@ void ChatRoomWidget::topicChanged()
     if (m_currentRoom)
     {
         auto topic = m_currentRoom->topic();
-        m_topicLabel->setText(topic.isEmpty() ? QStringLiteral("(no topic)") :
+        m_topicLabel->setText(topic.isEmpty() ? tr("(no topic)") :
                               m_currentRoom->prettyPrint(topic));
     }
     else
@@ -218,7 +218,8 @@ void ChatRoomWidget::sendInput()
             }
             else if( text.startsWith('/') )
             {
-                emit showStatusMessage( "Unknown command. Use // to send this line literally", 5000);
+                emit showStatusMessage(
+                    tr("Unknown command. Use // to send this line literally"), 5000);
                 return;
             } else
                 m_currentRoom->postMessage("m.text", text);

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -175,7 +175,11 @@ void ChatRoomWidget::typingChanged()
 void ChatRoomWidget::topicChanged()
 {
     if (m_currentRoom)
-        m_topicLabel->setText(m_currentRoom->prettyTopic());
+    {
+        auto topic = m_currentRoom->topic();
+        m_topicLabel->setText(topic.isEmpty() ? QStringLiteral("(no topic)") :
+                              m_currentRoom->prettyPrint(topic));
+    }
     else
         m_topicLabel->clear();
 }

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -29,8 +29,6 @@ class MessageEventModel;
 class ImageProvider;
 class QFrame;
 class QQuickView;
-class QListView;
-class QLineEdit;
 class QLabel;
 class QTextDocument;
 
@@ -42,9 +40,9 @@ class ChatRoomWidget: public QWidget
         virtual ~ChatRoomWidget();
 
         void enableDebug();
-        void triggerCompletion();
-        void cancelCompletion();
         bool pendingMarkRead() const;
+
+        QStringList findCompletionMatches(const QString& pattern) const;
 
     signals:
         void joinCommandEntered(const QString& roomAlias);
@@ -70,17 +68,7 @@ class ChatRoomWidget: public QWidget
         MessageEventModel* m_messageModel;
         QuaternionRoom* m_currentRoom;
         QMatrixClient::Connection* m_currentConnection;
-        bool m_completing;
-        QStringList m_completionList;
-        int m_completionListPosition;
-        int m_completionInsertStart;
-        int m_completionLength;
-        int m_completionCursorOffset;
 
-        void findCompletionMatches(const QString& pattern);
-        void startNewCompletion();
-
-        //QListView* m_messageView;
         QQuickView* m_quickView;
         ImageProvider* m_imageProvider;
         ChatEdit* m_chatEdit;

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -212,9 +212,7 @@ QVariant MessageEventModel::data(const QModelIndex& index, int role) const
                     if (textContent && textContent->mimeType.inherits("text/html"))
                         return textContent->body;
 
-                    auto body = e->plainBody().toHtmlEscaped();
-                    m_currentRoom->linkifyUrls(body);
-                    return body;
+                    return m_currentRoom->prettyPrint(e->plainBody());
                 }
             case MessageEventType::Image:
                 {

--- a/client/quaternionroom.cpp
+++ b/client/quaternionroom.cpp
@@ -147,11 +147,10 @@ void QuaternionRoom::linkifyUrls(QString& text) const
                  QStringLiteral("\\1<a href=\"\\2\">\\2</a>"));
 }
 
-QString QuaternionRoom::prettyTopic() const
+QString QuaternionRoom::prettyPrint(const QString& plainText) const
 {
-    QString pt = topic().toHtmlEscaped();
-    if (pt.isEmpty())
-        return QStringLiteral("(no topic)");
+    auto pt = plainText.toHtmlEscaped();
+    pt.replace('\n', "<br/>");
 
     linkifyUrls(pt);
     return pt;

--- a/client/quaternionroom.h
+++ b/client/quaternionroom.h
@@ -46,8 +46,9 @@ class QuaternionRoom: public QMatrixClient::Room
 
         /** Converts all that looks like a URL into HTML links */
         void linkifyUrls(QString& text) const;
-        /** Returns pretty-printed room topic in HTML */
-        QString prettyTopic() const;
+
+        /** Returns the passed plain text pretty-printed in HTML */
+        QString prettyPrint(const QString& plainText) const;
 
     protected:
         virtual void doAddNewMessageEvents(const QMatrixClient::Events& events) override;


### PR DESCRIPTION
The refactoring moves the tab completion code to `ChatEdit` where it naturally belongs and, since `ChatEdit` becomes quite a bit of almost self-contained functionality, it gets its own pair of files. Oh, and notably - the tab completion code now uses `QTextCursor` instead of indices, which allows to input rich text without breaking completion. Bonus: fancy underlining of the currently-completed piece.