### PR TITLE
Fix tab completion

### DIFF
--- a/client/chatedit.cpp
+++ b/client/chatedit.cpp
@@ -49,7 +49,7 @@ void ChatEdit::startNewCompletion()
     completionCursor.clearSelection();
     while ( completionCursor.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor) )
     {
-        auto firstChar = completionCursor.selectedText()[0];
+        auto firstChar = completionCursor.selectedText().at(0);
         if (!firstChar.isLetterOrNumber() && firstChar != '@')
         {
             completionCursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);


### PR DESCRIPTION
The [] QString operator has many overloads, one of them returning a
QCharRef. This particular overload might point to an invalidated
reference, because selectedText() is a temporary QString. This happens
at least on Linux platforms, where selectedText()[0] would return a null
QCharRef. Replacing the [] operator with .at(0) ensures that we get a
const QChar, which is what we want.