### PR TITLE
Add support for flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ There's no official packaging at the moment. Some links to unofficial packages f
 Arch Linux: https://aur.archlinux.org/packages/quaternion/
 Windows: automatic builds are packaged upon every commit (CI) at https://ci.appveyor.com/project/Fxrh/quaternion (go to "Jobs", select the job for your architecture, then "Artifacts")
 
+## Flatpak
+
+If your run Linux and your distribution supports flatpak, you can easily build and install Quaternion as flatpak package:
+
+```
+git clone https://github.com/Fxrh/Quaternion.git --recursive
+cd Quaternion/flatpak
+./setup_repo.sh
+./build.sh
+flatpak --user install quaternion-nightly com.github.quaternion
+```
+Whenever you want to update your Quaternion package, just run again the `build.sh` script and then use:
+
+```
+flatpak --user update
+```
+
 ## Troubleshooting
 
 If `cmake` fails with...

--- a/flatpak/build.sh
+++ b/flatpak/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+flatpak-builder --ccache --force-clean --require-changes --repo=repo --subject="Nightly build of Quaternion, `date`" ${EXPORT_ARGS-} app com.github.quaternion.json
+
+flatpak --user remote-add --if-not-exists quaternion-nightly repo --no-gpg-verify

--- a/flatpak/com.github.quaternion.json
+++ b/flatpak/com.github.quaternion.json
@@ -1,0 +1,21 @@
+{
+    "id": "com.github.quaternion",
+    "branch": "master",
+    "rename-icon": "quaternion",
+    "rename-desktop-file": "quaternion.desktop",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "master",
+    "sdk": "org.kde.Sdk",
+    "command": "quaternion",
+    "tags": ["nightly"],
+    "desktop-file-name-prefix": "(Nightly) ",
+    "finish-args": ["--share=ipc", "--share=network", "--socket=x11", "--socket=wayland", "--env=QT_QPA_PLATFORM=flatpak"],
+
+    "modules": [
+        {
+            "name": "quaternion",
+            "cmake": true,
+            "sources": [ { "type": "git", "url": "git://github.com/Fxrh/Quaternion.git" } ]
+        }
+    ]
+}

--- a/flatpak/setup_runtime.sh
+++ b/flatpak/setup_runtime.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+flatpak --user remote-add kderuntime --if-not-exists --from https://distribute.kde.org/kderuntime.flatpakrepo
+flatpak --user install kderuntime org.kde.Platform
+flatpak --user install kderuntime org.kde.Sdk


### PR DESCRIPTION
Flatpak is a Linux tool that allows cross-distribution packages. This
commit adds the JSON manifest file necessary to locally build a flatpak package.

Qt is picked from the flatpak runtime provided by KDE. A couple of
scripts contain the necessary flatpak commands to build and install the
flatpak package.