### PR TITLE
Multiple accounts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can also file outright bugs at [the project's issue tracker](https://github.
 
 ## Installing pre-requisites
 ### Linux
-Just install things from "Pre-requisites" using your preferred package manager. If your Qt package base is fine-grained you might want to take a look at CMakeLists.txt to figure out which specific libraries Quaternion uses (or blindly run cmake and look at error messages). Note also that you'll need several Qt Quick plugins for Quaternion to work (without them, it will compile and run but won't show the messages timeline). In case of Trusty Tar the following line will get you everything necessary to build and run Quaternion (thanks to @onlnr:matrix.org):
+Just install things from "Pre-requisites" using your preferred package manager. If your Qt package base is fine-grained you might want to take a look at `CMakeLists.txt` to figure out which specific libraries Quaternion uses (or blindly run cmake and look at error messages). Note also that you'll need several Qt Quick plugins for Quaternion to work (without them, it will compile and run but won't show the messages timeline). In case of Trusty Tar the following line will get you everything necessary to build and run Quaternion (thanks to `@onlnr:matrix.org`):
 ```
 sudo apt-get install git cmake qtdeclarative5-dev qtdeclarative5-qtquick2-plugin qtdeclarative5-controls-plugin
 ```
@@ -114,6 +114,8 @@ CMake Error at CMakeLists.txt:30 (add_subdirectory):
 If Quaternion runs but you can't see any messages in the chat (though you can type them in) - you have a problem with Qt Quick. Most likely, you don't have Qt Quick libraries and/or plugins installed. On Linux, double check "Pre-requisites" above. On Windows and Mac, just open an issue (see "Contacts" section in the beginning of this README), because most likely not all necessary Qt parts got installed.
 
 Especially on Windows, if Quaternion starts up but upon an attempt to connect returns a message like "Failed to make SSL context" - you haven't made sure that SSL libraries are reachable buy the Quaternion binary. See the "Installation on Windows" section above for details.
+
+When chasing bugs and investigating crashes, it helps to increase the debug level. Thanks to @eang:matrix.org, libqmatrixclient uses Qt logging categories - the "Troubleshooting" section of `lib/README.md` elaborates on how to setup logging.
 
 ## Screenshot
 ![Screenshot](quaternion.png)

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -108,6 +108,7 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
         m_currentRoom->setCachedInput( m_chatEdit->toPlainText() );
         m_currentRoom->setShown(false);
         roomHistories.insert(m_currentRoom, m_chatEdit->history());
+        m_currentRoom->connection()->disconnect(this);
         m_currentRoom->disconnect( this );
     }
     readMarkerOnScreen = false;
@@ -136,6 +137,11 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
                                  rm->index() ) != indicesOnScreen.end();
             reStartShownTimer();
             emit readMarkerMoved();
+        });
+        connect(m_currentRoom->connection(), &Connection::loggedOut, this, [=]
+        {
+            qWarning() << "Logged out, escaping the room";
+            setRoom(nullptr);
         });
 
         m_currentRoom->setShown(true);

--- a/client/chatroomwidget.cpp
+++ b/client/chatroomwidget.cpp
@@ -19,7 +19,6 @@
 
 #include "chatroomwidget.h"
 
-#include <QtCore/QDebug>
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QLabel>
 
@@ -30,7 +29,6 @@
 
 #include "lib/user.h"
 #include "lib/connection.h"
-#include "lib/events/typingevent.h"
 #include "models/messageeventmodel.h"
 #include "imageprovider.h"
 #include "chatedit.h"
@@ -38,7 +36,6 @@
 ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     : QWidget(parent)
     , m_currentRoom(nullptr)
-    , m_currentConnection(nullptr)
     , readMarkerOnScreen(false)
 {
     qmlRegisterType<QuaternionRoom>();
@@ -56,7 +53,7 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
 
     m_quickView = new QQuickView();
 
-    m_imageProvider = new ImageProvider(m_currentConnection);
+    m_imageProvider = new ImageProvider(nullptr); // No connection yet
     m_quickView->engine()->addImageProvider("mtx", m_imageProvider);
 
     QWidget* container = QWidget::createWindowContainer(m_quickView, this);
@@ -93,10 +90,6 @@ ChatRoomWidget::ChatRoomWidget(QWidget* parent)
     setLayout(layout);
 }
 
-ChatRoomWidget::~ChatRoomWidget()
-{
-}
-
 void ChatRoomWidget::enableDebug()
 {
     QQmlContext* ctxt = m_quickView->rootContext();
@@ -110,27 +103,32 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
         return;
     }
 
+    if( m_currentRoom )
+    {
+        m_currentRoom->setCachedInput( m_chatEdit->toPlainText() );
+        m_currentRoom->setShown(false);
+        roomHistories.insert(m_currentRoom, m_chatEdit->history());
+        m_currentRoom->disconnect( this );
+    }
     readMarkerOnScreen = false;
     maybeReadTimer.stop();
     indicesOnScreen.clear();
     m_chatEdit->cancelCompletion();
-    if( m_currentRoom )
-    {
-        m_currentRoom->setCachedInput( m_chatEdit->toPlainText() );
-        m_currentRoom->disconnect( this );
-        m_currentRoom->setShown(false);
-        roomHistories.insert(m_currentRoom, m_chatEdit->history());
-    }
+
     m_currentRoom = room;
     if( m_currentRoom )
     {
+        using namespace QMatrixClient;
+        m_imageProvider->setConnection(room->connection());
         m_chatEdit->setText( m_currentRoom->cachedInput() );
         m_chatEdit->setHistory(roomHistories.value(m_currentRoom));
         m_chatEdit->setFocus();
         m_chatEdit->moveCursor(QTextCursor::End);
-        connect( m_currentRoom, &QMatrixClient::Room::typingChanged, this, &ChatRoomWidget::typingChanged );
-        connect( m_currentRoom, &QMatrixClient::Room::topicChanged, this, &ChatRoomWidget::topicChanged );
-        connect( m_currentRoom, &QMatrixClient::Room::readMarkerMoved, this, [this] {
+        connect( m_currentRoom, &Room::typingChanged,
+                 this, &ChatRoomWidget::typingChanged );
+        connect( m_currentRoom, &Room::topicChanged,
+                 this, &ChatRoomWidget::topicChanged );
+        connect( m_currentRoom, &Room::readMarkerMoved, this, [this] {
             const auto rm = m_currentRoom->readMarker();
             readMarkerOnScreen =
                 rm != m_currentRoom->timelineEdge() &&
@@ -139,21 +137,15 @@ void ChatRoomWidget::setRoom(QuaternionRoom* room)
             reStartShownTimer();
             emit readMarkerMoved();
         });
+
         m_currentRoom->setShown(true);
-    }
+    } else
+        m_imageProvider->setConnection(nullptr);
     topicChanged();
     typingChanged();
     m_messageModel->changeRoom( m_currentRoom );
-    //m_messageView->scrollToBottom();
     QObject* rootItem = m_quickView->rootObject();
     QMetaObject::invokeMethod(rootItem, "scrollToBottom");
-}
-
-void ChatRoomWidget::setConnection(QMatrixClient::Connection* connection)
-{
-    setRoom(nullptr);
-    m_currentConnection = connection;
-    m_imageProvider->setConnection(connection);
 }
 
 void ChatRoomWidget::typingChanged()
@@ -187,8 +179,6 @@ void ChatRoomWidget::topicChanged()
 void ChatRoomWidget::sendInput()
 {
     qDebug() << "sendLine";
-    if( !m_currentConnection )
-        return;
     QString text = m_chatEdit->toPlainText();
     if ( text.isEmpty() )
         return;
@@ -204,7 +194,7 @@ void ChatRoomWidget::sendInput()
         {
             if( text.startsWith("/leave") )
             {
-                m_currentConnection->leaveRoom( m_currentRoom );
+                m_currentRoom->leaveRoom();
             }
             else if( text.startsWith("/me") )
             {
@@ -333,8 +323,7 @@ void ChatRoomWidget::timerEvent(QTimerEvent* qte)
 
 void ChatRoomWidget::markShownAsRead()
 {
-    // FIXME: This doesn't cover a case when a single message doesn't fit
-    // on the screen.
+    // FIXME: a case when a single message doesn't fit on the screen.
     if (m_currentRoom && readMarkerOnScreen)
     {
         const auto iter = m_currentRoom->findInTimeline(indicesOnScreen.back());

--- a/client/chatroomwidget.h
+++ b/client/chatroomwidget.h
@@ -27,6 +27,7 @@
 class ChatEdit;
 class MessageEventModel;
 class ImageProvider;
+
 class QFrame;
 class QQuickView;
 class QLabel;
@@ -36,8 +37,7 @@ class ChatRoomWidget: public QWidget
 {
         Q_OBJECT
     public:
-        ChatRoomWidget(QWidget* parent = nullptr);
-        virtual ~ChatRoomWidget();
+        explicit ChatRoomWidget(QWidget* parent = nullptr);
 
         void enableDebug();
         bool pendingMarkRead() const;
@@ -52,7 +52,6 @@ class ChatRoomWidget: public QWidget
 
     public slots:
         void setRoom(QuaternionRoom* room);
-        void setConnection(QMatrixClient::Connection* connection);
         void topicChanged();
         void typingChanged();
         void onMessageShownChanged(QString eventId, bool shown);
@@ -67,7 +66,6 @@ class ChatRoomWidget: public QWidget
     private:
         MessageEventModel* m_messageModel;
         QuaternionRoom* m_currentRoom;
-        QMatrixClient::Connection* m_currentConnection;
 
         QQuickView* m_quickView;
         ImageProvider* m_imageProvider;

--- a/client/imageprovider.h
+++ b/client/imageprovider.h
@@ -20,38 +20,29 @@
 #pragma once
 
 #include <QtQuick/QQuickImageProvider>
-#include <QtCore/QThread>
 #include <QtCore/QMutex>
 #include <QtCore/QWaitCondition>
 
-#include <lib/jobs/basejob.h>
-#include "quaternionconnection.h"
-
-struct ImageProviderData
-{
-    QPixmap* pixmap;
-    QWaitCondition* condition;
-    QSize requestedSize;
-};
+namespace QMatrixClient {
+    class Connection;
+}
 
 class ImageProvider: public QObject, public QQuickImageProvider
 {
         Q_OBJECT
     public:
-        ImageProvider(QMatrixClient::Connection* connection);
+        explicit ImageProvider(QMatrixClient::Connection* connection);
 
-        QPixmap requestPixmap(const QString& id, QSize* size, const QSize& requestedSize);
+        QPixmap requestPixmap(const QString& id, QSize* size,
+                              const QSize& requestedSize) override;
 
-        void setConnection(QMatrixClient::Connection* connection);
-
-    private slots:
-        void gotImage(QMatrixClient::BaseJob* job);
+        void setConnection(const QMatrixClient::Connection* connection);
 
     private:
-        Q_INVOKABLE void doRequest(QString id, QSize requestedSize, QPixmap* pixmap, QWaitCondition* condition);
+        Q_INVOKABLE void doRequest(QString id, QSize requestedSize,
+                                   QPixmap* pixmap, QWaitCondition* condition);
 
-        QMatrixClient::Connection* m_connection;
-        QHash<QMatrixClient::MediaThumbnailJob*, ImageProviderData> m_callmap;
+        const QMatrixClient::Connection* m_connection;
         QMutex m_mutex;
 };
 

--- a/client/mainwindow.cpp
+++ b/client/mainwindow.cpp
@@ -23,9 +23,7 @@
 #include <QtCore/QDebug>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMenuBar>
-#include <QtWidgets/QMenu>
 #include <QtWidgets/QMessageBox>
-#include <QtWidgets/QAction>
 #include <QtWidgets/QInputDialog>
 #include <QtWidgets/QStatusBar>
 #include <QtWidgets/QLabel>
@@ -34,7 +32,6 @@
 
 #include "jobs/joinroomjob.h"
 #include "quaternionconnection.h"
-#include "quaternionroom.h"
 #include "roomlistdock.h"
 #include "userlistdock.h"
 #include "chatroomwidget.h"
@@ -42,10 +39,11 @@
 #include "systemtray.h"
 #include "settings.h"
 
+class QuaternionRoom;
+
 MainWindow::MainWindow()
 {
     setWindowIcon(QIcon(":/icon.png"));
-    connection = nullptr;
     roomListDock = new RoomListDock(this);
     addDockWidget(Qt::LeftDockWidgetArea, roomListDock);
     userListDock = new UserListDock(this);
@@ -53,8 +51,12 @@ MainWindow::MainWindow()
     chatRoomWidget = new ChatRoomWidget(this);
     setCentralWidget(chatRoomWidget);
     connect( chatRoomWidget, &ChatRoomWidget::joinCommandEntered, this, &MainWindow::joinRoom );
-    connect( roomListDock, &RoomListDock::roomSelected, chatRoomWidget, &ChatRoomWidget::setRoom );
-    connect( roomListDock, &RoomListDock::roomSelected, userListDock, &UserListDock::setRoom );
+    connect( roomListDock, &RoomListDock::roomSelected, [=](QuaternionRoom *r)
+    {
+        setWindowTitle(r->displayName());
+        chatRoomWidget->setRoom(r);
+        userListDock->setRoom(r);
+    } );
     connect( chatRoomWidget, &ChatRoomWidget::showStatusMessage, statusBar(), &QStatusBar::showMessage );
     systemTray = new SystemTray(this);
     createMenu();
@@ -77,16 +79,17 @@ ChatRoomWidget* MainWindow::getChatRoomWidget() const
 void MainWindow::createMenu()
 {
     // Connection menu
-    auto connectionMenu = menuBar()->addMenu(tr("&Connection"));
+    connectionMenu = menuBar()->addMenu(tr("&Accounts"));
 
-    loginAction = connectionMenu->addAction(tr("&Login..."));
-    connect( loginAction, &QAction::triggered, [=]{ showLoginWindow(); } );
-
-    logoutAction = connectionMenu->addAction(tr("&Logout"));
-    connect( logoutAction, &QAction::triggered, [=]{ logout(); } );
-    logoutAction->setEnabled(false); // we start in a logged out state
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    connectionMenu->addAction(tr("&Login..."), this, [=]{ showLoginWindow(); } );
+#else
+    connectionMenu->addAction(tr("&Login..."), this, SLOT(showLoginWindow()));
+#endif
 
     connectionMenu->addSeparator();
+    // Logout actions will be added between these two separators - see onConnected()
+    accountListGrowthPoint = connectionMenu->addSeparator();
 
     auto quitAction = connectionMenu->addAction(tr("&Quit"));
     quitAction->setShortcut(QKeySequence::Quit);
@@ -142,32 +145,31 @@ void MainWindow::initialize()
     invokeLogin();
 }
 
-void MainWindow::setConnection(QuaternionConnection* newConnection)
+void MainWindow::addConnection(QuaternionConnection* c)
 {
-    if (connection)
-    {
+    Q_ASSERT_X(c, __FUNCTION__, "Attempt to add a null connection");
 
-        connection->stopSync();
-        connection->deleteLater();
-    }
+    connections.push_back(c);
 
-    connection = newConnection;
-    loginAction->setEnabled(connection == nullptr); // Don't support multiple accounts yet
-    logoutAction->setEnabled(connection != nullptr);
+    roomListDock->addConnection(c);
 
-    if (connection)
-    {
-        roomListDock->setConnection(connection);
+    using QMatrixClient::Connection;
+    connect( c, &Connection::connected, this, [=]{ onConnected(c); } );
+    connect( c, &Connection::syncDone, this, [=]{ gotEvents(c); } );
+    connect( c, &Connection::loggedOut, this, [=]{ dropConnection(c); } );
+    connect( c, &Connection::networkError, this, [=]{ networkError(c); } );
+    connect( c, &Connection::loginError,
+             this, [=](const QString& msg){ loginError(c, msg); } );
+    connect( c, &Connection::newRoom, systemTray, &SystemTray::newRoom );
+}
 
-        using QMatrixClient::Connection;
-        connect( connection, &Connection::networkError, this, &MainWindow::networkError );
-        connect( connection, &Connection::syncDone, this, &MainWindow::gotEvents );
-        connect( connection, &Connection::connected, this, &MainWindow::initialSync );
-        // Short-circuit login errors to logged-out events
-        connect( connection, &Connection::loginError, connection, &Connection::loggedOut );
-        connect( connection, &Connection::loggedOut, [=]{ loggedOut(); } );
-        connect( connection, &Connection::newRoom, systemTray, &SystemTray::newRoom );
-    }
+void MainWindow::dropConnection(QuaternionConnection* c)
+{
+    Q_ASSERT_X(c, __FUNCTION__, "Attempt to drop a null connection");
+
+    connections.removeOne(c);
+    Q_ASSERT(!connections.contains(c));
+    c->deleteLater();
 }
 
 void MainWindow::showLoginWindow(const QString& statusMessage)
@@ -176,8 +178,7 @@ void MainWindow::showLoginWindow(const QString& statusMessage)
     dialog.setStatusMessage(statusMessage);
     if( dialog.exec() )
     {
-        setConnection(dialog.connection());
-
+        auto connection = dialog.connection();
         QMatrixClient::AccountSettings account(connection->userId());
         account.setKeepLoggedIn(dialog.keepLoggedIn());
         if (dialog.keepLoggedIn())
@@ -187,7 +188,8 @@ void MainWindow::showLoginWindow(const QString& statusMessage)
         }
         account.sync();
 
-        initialSync();
+        addConnection(connection);
+        onConnected(connection);
     }
 }
 
@@ -200,52 +202,56 @@ void MainWindow::invokeLogin()
         AccountSettings account { accountId };
         if (!account.accessToken().isEmpty())
         {
-            // TODO: Support multiple accounts
-            // Right now the code just finds the first configured account,
-            // rather than connects all available.
-            setConnection(new QuaternionConnection(account.homeserver()));
-            connection->connectWithToken(account.userId(), account.accessToken());
-            return;
+            auto c = new QuaternionConnection(account.homeserver());
+            addConnection(c);
+            c->connectWithToken(account.userId(), account.accessToken());
         }
     }
-    // No accounts to automatically log into
-    showLoginWindow();
+    if (connections.isEmpty())
+        showLoginWindow();
 }
 
-void MainWindow::logout()
+void MainWindow::loginError(QuaternionConnection* c, const QString& message)
 {
-    if( !connection )
-        return; // already logged out
-
-    QMatrixClient::AccountSettings account { connection->userId() };
-    account.clearAccessToken();
-    account.sync();
-
-    connection->logout();
-}
-
-void MainWindow::loggedOut(const QString& message)
-{
-    loginAction->setEnabled(true);
-    logoutAction->setEnabled(false);
-    setConnection(nullptr);
+    Q_ASSERT_X(c, __FUNCTION__, "Login error on a null connection");
+    // FIXME: Make ConnectionManager instead of such hacks
+    emit c->loggedOut(); // Short circuit login error to logged-out event
     showLoginWindow(message);
 }
 
-void MainWindow::initialSync()
+void MainWindow::logout(QuaternionConnection* c)
 {
-    setWindowTitle(connection->userId());
+    Q_ASSERT_X(c, __FUNCTION__, "Logout on a null connection");
+
+    QMatrixClient::AccountSettings account { c->userId() };
+    account.clearAccessToken();
+    account.sync();
+
+    c->logout();
+}
+
+void MainWindow::onConnected(QuaternionConnection* c)
+{
+    Q_ASSERT_X(c, __FUNCTION__, "Null connection");
+    auto logoutAction = new QAction(tr("Logout %1").arg(c->userId()), c);
+    connectionMenu->insertAction(accountListGrowthPoint, logoutAction);
+    connect( logoutAction, &QAction::triggered, this, [=]{ logout(c); } );
+    connect( c, &QMatrixClient::Connection::destroyed, this, [=]
+    {
+        connectionMenu->removeAction(logoutAction);
+    } );
+
     busyLabel->show();
     busyIndicator->start();
     statusBar()->showMessage("Syncing, please wait...");
-    getNewEvents();
+    getNewEvents(c);
 }
 
 void MainWindow::joinRoom(const QString& roomAlias)
 {
-    if (!connection)
+    if (connections.isEmpty())
     {
-        QMessageBox::warning(this, tr("No connection"),
+        QMessageBox::warning(this, tr("No connections"),
             tr("Please connect to a server before joining a room"),
             QMessageBox::Close, QMessageBox::Close);
         return;
@@ -261,7 +267,8 @@ void MainWindow::joinRoom(const QString& roomAlias)
         return;
 
     using QMatrixClient::JoinRoomJob;
-    auto job = connection->joinRoom(room);
+    // FIXME: only the first account is used to join a room
+    auto job = connections.front()->joinRoom(room);
     connect(job, &QMatrixClient::BaseJob::failure, this, [=] {
         QMessageBox messageBox(QMessageBox::Warning,
                                tr("Failed to join room"),
@@ -285,20 +292,22 @@ void MainWindow::joinRoom(const QString& roomAlias)
     });
 }
 
-void MainWindow::getNewEvents()
+void MainWindow::getNewEvents(QuaternionConnection* c)
 {
-    connection->sync(30*1000);
+    Q_ASSERT_X(c, __FUNCTION__, "Attempt to sync on null connection");
+    c->sync(30*1000);
 }
 
-void MainWindow::gotEvents()
+void MainWindow::gotEvents(QuaternionConnection* c)
 {
+    Q_ASSERT_X(c, __FUNCTION__, "Null connection");
     if( busyLabel->isVisible() )
     {
         busyLabel->hide();
         busyIndicator->stop();
-        statusBar()->showMessage(tr("Connected as %1").arg(connection->userId()), 5000);
+        statusBar()->showMessage(tr("Connected as %1").arg(c->userId()), 5000);
     }
-    getNewEvents();
+    getNewEvents(c);
 }
 
 void showMillisToRecon(QStatusBar* statusBar, int millis)
@@ -308,14 +317,15 @@ void showMillisToRecon(QStatusBar* statusBar, int millis)
         .arg((millis + 999) / 1000)); // Integer ceiling
 }
 
-void MainWindow::networkError()
+void MainWindow::networkError(QuaternionConnection* c)
 {
+    Q_ASSERT_X(c, __FUNCTION__, "Network error on a null connection");
     auto timer = new QTimer(this);
-    timer->start(std::min(1000, connection->millisToReconnect()));
+    timer->start(std::min(1000, c->millisToReconnect()));
     showMillisToRecon(statusBar(), timer->remainingTime());
     timer->connect(timer, &QTimer::timeout, [=] {
-        if (connection->millisToReconnect() > 0)
-            showMillisToRecon(statusBar(), connection->millisToReconnect());
+        if (c->millisToReconnect() > 0)
+            showMillisToRecon(statusBar(), c->millisToReconnect());
         else
         {
             statusBar()->showMessage(tr("Reconnecting..."), 5000);
@@ -326,7 +336,9 @@ void MainWindow::networkError()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-    setConnection(nullptr);
+    for (auto c: connections)
+        dropConnection(c);
     saveSettings();
     event->accept();
 }
+

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -81,4 +81,5 @@ class MainWindow: public QMainWindow
         void invokeLogin();
         void loadSettings();
         void saveSettings() const;
+        void showMillisToRecon(QuaternionConnection* c);
 };

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -43,38 +43,39 @@ class MainWindow: public QMainWindow
 
         void enableDebug();
 
-        void setConnection(QuaternionConnection* newConnection);
+        void addConnection(QuaternionConnection* c);
+        void dropConnection(QuaternionConnection* c);
+
         ChatRoomWidget* getChatRoomWidget() const;
 
     protected:
-        virtual void closeEvent(QCloseEvent* event) override;
+        void closeEvent(QCloseEvent* event) override;
 
     private slots:
         void initialize();
-        void initialSync();
-        void joinRoom(const QString& roomAlias = QString());
-        void getNewEvents();
-        void gotEvents();
-        void loggedOut(const QString& message = QString());
+        void onConnected(QuaternionConnection* c);
+        void joinRoom(const QString& roomAlias = {});
+        void getNewEvents(QuaternionConnection* c);
+        void gotEvents(QuaternionConnection* c);
+        void loginError(QuaternionConnection* c, const QString& message = {});
 
-        void networkError();
+        void networkError(QuaternionConnection* c);
 
-        void showLoginWindow(const QString& statusMessage = QString());
-        void logout();
-
+        void showLoginWindow(const QString& statusMessage = {});
+        void logout(QuaternionConnection* c);
     private:
-        RoomListDock* roomListDock;
-        UserListDock* userListDock;
-        ChatRoomWidget* chatRoomWidget;
-        QuaternionConnection* connection;
+        RoomListDock* roomListDock = nullptr;
+        UserListDock* userListDock = nullptr;
+        ChatRoomWidget* chatRoomWidget = nullptr;
+        QList<QuaternionConnection*> connections;
 
-        QMovie* busyIndicator;
-        QLabel* busyLabel;
+        QMovie* busyIndicator = nullptr;
+        QLabel* busyLabel = nullptr;
 
-        QAction* loginAction;
-        QAction* logoutAction;
+        QMenu* connectionMenu = nullptr;
+        QAction* accountListGrowthPoint = nullptr;
 
-        SystemTray* systemTray;
+        SystemTray* systemTray = nullptr;
 
         void createMenu();
         void invokeLogin();

--- a/client/models/messageeventmodel.cpp
+++ b/client/models/messageeventmodel.cpp
@@ -74,7 +74,10 @@ void MessageEventModel::changeRoom(QuaternionRoom* room)
 
     beginResetModel();
     if( m_currentRoom )
+    {
         m_currentRoom->disconnect( this );
+        qDebug() << "Disconnected from" << m_currentRoom->id();
+    }
 
     m_currentRoom = room;
     if( room )
@@ -93,7 +96,8 @@ void MessageEventModel::changeRoom(QuaternionRoom* room)
                 });
         connect(m_currentRoom, &Room::addedMessages,
                 this, &MessageEventModel::endInsertRows);
-        qDebug() << "connected" << room;
+        qDebug() << "Connected to room" << room->id()
+                 << "as" << room->connection()->userId();
     }
     endResetModel();
 }

--- a/client/models/roomlistmodel.h
+++ b/client/models/roomlistmodel.h
@@ -39,7 +39,6 @@ class RoomListModel: public QAbstractListModel
         };
 
         RoomListModel(QObject* parent = nullptr);
-        virtual ~RoomListModel();
 
         void setConnection(QMatrixClient::Connection* connection);
         QuaternionRoom* roomAt(int row);

--- a/client/models/roomlistmodel.h
+++ b/client/models/roomlistmodel.h
@@ -23,10 +23,10 @@
 
 namespace QMatrixClient
 {
-    class Connection;
     class Room;
 }
 
+class QuaternionConnection;
 class QuaternionRoom;
 
 class RoomListModel: public QAbstractListModel
@@ -38,21 +38,22 @@ class RoomListModel: public QAbstractListModel
             HighlightCountRole,
         };
 
-        RoomListModel(QObject* parent = nullptr);
+        explicit RoomListModel(QObject* parent = nullptr);
 
-        void setConnection(QMatrixClient::Connection* connection);
+        void addConnection(QuaternionConnection* connection);
+        void deleteConnection(QuaternionConnection* connection);
         QuaternionRoom* roomAt(int row);
 
-        QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-        int rowCount(const QModelIndex& parent=QModelIndex()) const override;
+        QVariant data(const QModelIndex& index, int role) const override;
+        int rowCount(const QModelIndex& parent) const override;
 
     private slots:
-        void displaynameChanged(QMatrixClient::Room* room);
-        void unreadMessagesChanged(QMatrixClient::Room* room);
+        void displaynameChanged(QuaternionRoom* room);
+        void unreadMessagesChanged(QuaternionRoom* room);
         void addRoom(QMatrixClient::Room* room);
 
     private:
-        QMatrixClient::Connection* m_connection;
+        QList<QuaternionConnection*> m_connections;
         QList<QuaternionRoom*> m_rooms;
 
         void doAddRoom(QMatrixClient::Room* r);

--- a/client/models/userlistmodel.cpp
+++ b/client/models/userlistmodel.cpp
@@ -46,6 +46,7 @@ void UserListModel::setRoom(QMatrixClient::Room* room)
     beginResetModel();
     if( m_currentRoom )
     {
+        m_currentRoom->connection()->disconnect( this );
         m_currentRoom->disconnect( this );
         for( User* user: m_users )
             user->disconnect( this );
@@ -63,6 +64,8 @@ void UserListModel::setRoom(QMatrixClient::Room* room)
         {
             connect( user, &User::avatarChanged, this, &UserListModel::avatarChanged );
         }
+        connect( m_currentRoom->connection(), &Connection::loggedOut,
+                 this, [=] { setRoom(nullptr); } );
         qDebug() << m_users.count() << "user(s) in the room";
     }
     endResetModel();

--- a/client/quaternionconnection.cpp
+++ b/client/quaternionconnection.cpp
@@ -25,7 +25,7 @@ QuaternionConnection::QuaternionConnection(QUrl server, QObject* parent)
 {
 }
 
-QMatrixClient::Room* QuaternionConnection::createRoom(QString roomId)
+QMatrixClient::Room* QuaternionConnection::createRoom(const QString& roomId)
 {
     return new QuaternionRoom(this, roomId);
 }

--- a/client/quaternionconnection.h
+++ b/client/quaternionconnection.h
@@ -28,5 +28,5 @@ class QuaternionConnection: public QMatrixClient::Connection
         QuaternionConnection(QUrl server, QObject* parent = nullptr);
 
     protected:
-        virtual QMatrixClient::Room* createRoom(QString roomId);
+        virtual QMatrixClient::Room* createRoom(const QString& roomId);
 };

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -43,7 +43,8 @@ class RoomListItemDelegate : public QStyledItemDelegate
         QColor highlightColor;
 };
 
-void RoomListItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+void RoomListItemDelegate::paint(QPainter* painter,
+         const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
     QStyleOptionViewItem o { option };
 
@@ -63,7 +64,6 @@ void RoomListItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& 
 
 RoomListDock::RoomListDock(QWidget* parent)
     : QDockWidget("Rooms", parent)
-    , connection(nullptr)
 {
     setObjectName("RoomsDock");
     model = new RoomListModel(this);
@@ -89,14 +89,8 @@ RoomListDock::RoomListDock(QWidget* parent)
     connect(this, &QWidget::customContextMenuRequested, this, &RoomListDock::showContextMenu);
 }
 
-RoomListDock::~RoomListDock()
-{
-}
-
 void RoomListDock::setConnection( QMatrixClient::Connection* connection )
 {
-    emit roomSelected(nullptr);
-    this->connection = connection;
     model->setConnection(connection);
 }
 
@@ -131,23 +125,24 @@ void RoomListDock::showContextMenu(const QPoint& pos)
 
 QuaternionRoom* RoomListDock::getSelectedRoom() const
 {
-    if (!connection)
-        return nullptr;
-
     QModelIndex index = view->currentIndex();
     return !index.isValid() ? nullptr : model->roomAt(index.row());
 }
 
 void RoomListDock::menuJoinSelected()
 {
+    // The user has been invited to the room
     if (auto room = getSelectedRoom())
-        connection->joinRoom(room->id());
+    {
+        Q_ASSERT(room->connection());
+        room->connection()->joinRoom(room->id());
+    }
 }
 
 void RoomListDock::menuLeaveSelected()
 {
     if (auto room = getSelectedRoom())
-        connection->leaveRoom(room);
+        room->leaveRoom();
 }
 
 void RoomListDock::menuMarkReadSelected()

--- a/client/roomlistdock.cpp
+++ b/client/roomlistdock.cpp
@@ -89,9 +89,9 @@ RoomListDock::RoomListDock(QWidget* parent)
     connect(this, &QWidget::customContextMenuRequested, this, &RoomListDock::showContextMenu);
 }
 
-void RoomListDock::setConnection( QMatrixClient::Connection* connection )
+void RoomListDock::addConnection(QuaternionConnection* connection)
 {
-    model->setConnection(connection);
+    model->addConnection(connection);
 }
 
 void RoomListDock::rowSelected(const QModelIndex& index)

--- a/client/roomlistdock.h
+++ b/client/roomlistdock.h
@@ -32,8 +32,7 @@ class RoomListDock : public QDockWidget
 {
         Q_OBJECT
     public:
-        RoomListDock(QWidget* parent = nullptr);
-        virtual ~RoomListDock();
+        explicit RoomListDock(QWidget* parent = nullptr);
 
         void setConnection( QMatrixClient::Connection* connection );
 
@@ -48,7 +47,6 @@ class RoomListDock : public QDockWidget
         void menuMarkReadSelected();
 
     private:
-        QMatrixClient::Connection* connection;
         QListView* view;
         RoomListModel* model;
         QMenu* contextMenu;

--- a/client/roomlistdock.h
+++ b/client/roomlistdock.h
@@ -23,7 +23,7 @@
 #include <QtWidgets/QListView>
 #include <QtCore/QStringListModel>
 
-#include "lib/connection.h"
+#include "quaternionconnection.h"
 
 class RoomListModel;
 class QuaternionRoom;
@@ -34,7 +34,7 @@ class RoomListDock : public QDockWidget
     public:
         explicit RoomListDock(QWidget* parent = nullptr);
 
-        void setConnection( QMatrixClient::Connection* connection );
+        void addConnection(QuaternionConnection* connection);
 
     signals:
         void roomSelected(QuaternionRoom* room);

--- a/client/systemtray.cpp
+++ b/client/systemtray.cpp
@@ -26,28 +26,15 @@
 
 SystemTray::SystemTray(QWidget* parent)
     : QSystemTrayIcon(parent)
-    , m_connection(nullptr)
     , m_parent(parent)
 {
     setIcon(QIcon(":/icon.png"));
 }
 
-void SystemTray::setConnection(QMatrixClient::Connection* connection)
-{
-    if( m_connection )
-    {
-        m_connection->disconnect(this);
-    }
-    m_connection = connection;
-    if( m_connection )
-    {
-        connect(m_connection, &QMatrixClient::Connection::newRoom, this, &SystemTray::newRoom);
-    }
-}
-
 void SystemTray::newRoom(QMatrixClient::Room* room)
 {
-    connect(room, &QMatrixClient::Room::highlightCountChanged, this, &SystemTray::highlightCountChanged);
+    connect(room, &QMatrixClient::Room::highlightCountChanged,
+            this, &SystemTray::highlightCountChanged);
 }
 
 void SystemTray::highlightCountChanged(QMatrixClient::Room* room)

--- a/client/systemtray.h
+++ b/client/systemtray.h
@@ -31,15 +31,14 @@ class SystemTray: public QSystemTrayIcon
 {
         Q_OBJECT
     public:
-        SystemTray(QWidget* parent = nullptr);
+        explicit SystemTray(QWidget* parent = nullptr);
 
-        void setConnection(QMatrixClient::Connection* connection);
+    public slots:
+        void newRoom(QMatrixClient::Room* room);
 
     private slots:
-        void newRoom(QMatrixClient::Room* room);
         void highlightCountChanged(QMatrixClient::Room* room);
 
     private:
-        QMatrixClient::Connection* m_connection;
         QWidget* m_parent;
 };


### PR DESCRIPTION
This adds (raw) support for multiple accounts. It basically has 3 parts:
- the first two commits are cleanup, logging tweaks, update to the latest lib API, refactoring. This can be (carefully) disposed of if it has something wrong. The latest lib (from the not yet merged https://github.com/Fxrh/libqmatrixclient/pull/62) is necessary to expose `Connection` from `Room`.
- the next two commits are preparation. Here I unbind components from "global" `Connection` and make some code more defensive so that I don't need to take care of deleted connections too much in `MainWindow`.
- the last commit is the main thing. Here I replace a single `Connection` pointer with a container, rewire connections adding/dropping and modify `RoomListModel` so that it can show rooms from several accounts as well as delete rooms from no more available connections.

The provided UI and functionality are as follows:
- A user can login to several accounts at the same time (Login menu item is always enabled and there are multiple Logout menu items, by the number of accounts)
- Most of the UI components now deal with room's connections rather than a single global connection thrown around through parameters and `setConnection()` calls.
- Room list shows all rooms from all accounts. In practice the rooms are grouped by account, in the order of the first sync response. This needs improvement desperately but is workable for smaller cases.

If you just want to try/review multiple accounts feature and do not plan to further contribute, you can stop reading at this point.

Things to do/discuss further with libqmatrixclient and Q around this functionality (and adventurous minds can already fork this branch and make a "PR to PR"; discussions in #quaternion are also more than welcome):
1. There's a dubious distinction between `loginError` and `loggedOut` signals in `Connection`. In reality `loginError` is emitted in cases where something terribly bad goes on with user's access - such as `AuthenticationRequired` response returned from a `/sync` REST call. I suppose we have to merge these into one signal.
2. A logged out connection lives for a very short time and its status in general is unclear. In theory the libqmatrixclient code could support relogin in such case (and there's a `reconnect()` method that does exactly that) - however, Quaternion simply disposes of logged out connections as soon as it detects them. Given that logout (as well as login error, see the previous question) basically mean that the password is not (or no more) effectual, seems that this is the only reasonable way to deal with such connections. If that's the case, emitting `Connection::loggedOut` may be followed by `deleteLater()` right in the `Connection` code.
3. There's quite a bit of connection orchestration code that now resides in `MainWindow` but is very well worth putting in the library. There's a rationale for a `QMatrixClient::ConnectionManager` class. A similar `RoomManager` class would also be very nice to have and could serve as a library base for the room list model, or even the model itself.
4. `RoomListModel`, apparently needs to be converted to a tree. This is needed at least to select them by account, and also to make use of room tags. There's quite a bit of interesting work on the backend here; one will have to master `QAbstractTreeModel`.
5. You cannot do anything but login/logout with accounts. Given that we don't even have `account_data` parsed from `sync()`, this makes sense so far, but in the future account settings should be extended with more centralised login experience (see the most recent GNOME for a possible example, and KDE, I guess, has a similar thing), editing per-account things like personal userpic/avatar and "remember me" flag, etc. A big piece of work, mostly on the UI.